### PR TITLE
Use devel container image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/cpp
 {
 	"name": "R-Dev-Env",
-	"image": "ghcr.io/r-devel/r-dev-env:dev-container",
+	"image": "ghcr.io/r-devel/r-dev-env:devel",
 	"hostRequirements": {
 		"cpus": 4
 	},


### PR DESCRIPTION
This pull request contains a minor change to the .devcontainer file so that the docker image generated from the devel branch is used as the base for the devcontainer.