### PR TITLE
update:builds docker images with latest R version twice a month automatically

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,7 +18,6 @@
 				"mads-hartmann.bash-ide-vscode",
 				"johnstoncode.svn-scm",
 				"ms-vscode.cpptools",
-				"ms-vscode.makefile-tools",
 				"MS-vsliveshare.vsliveshare"
 			]
 			

--- a/.github/workflows/build-and-publish-image.yml
+++ b/.github/workflows/build-and-publish-image.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Extract version number
         run: |

--- a/.github/workflows/build-and-publish-image.yml
+++ b/.github/workflows/build-and-publish-image.yml
@@ -8,6 +8,9 @@ name: Build and publish Docker image
 on:
   push:
     branches: ["devel"]
+  schedule:
+    - cron: '0 0 1,15 * *'
+  
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
The schedule is added to the Github Actions workflow to build docker image automatically twice a month.
This will pull latest R version and build docker image using it.

PR for issue : #84 