### PR TITLE
update:rm .git dir and setting to show svn repo

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,8 @@
 		"vscode": {
 			"settings": {
 				"r.rpath.linux": "/usr/bin/R",
-                "r.rterm.linux": "/usr/bin/R"
+                "r.rterm.linux": "/usr/bin/R",
+				"svn.multipleFolders.enabled": true
 			},
 			"extensions": [
 				"REditorSupport.r",

--- a/scripts/localscript.sh
+++ b/scripts/localscript.sh
@@ -8,3 +8,7 @@ chmod +x /workspaces/r-dev-env/scripts/multi_r.sh
 
 mv /workspaces/r-dev-env/scripts/rterm.sh /home/vscode/.local/bin/rterm
 cp /workspaces/r-dev-env/scripts/multi_r.sh /home/vscode/.local/bin/multi_r
+
+#remove git directory
+cd /workspaces/r-dev-env
+rm -rf .git


### PR DESCRIPTION
PR for issue no. #85 and #86 

##### 1. The SVN extension now shows installed repos and history from svn. 
##### 2. command to remove .git dir is added to scripts/localscript file, which is triggered when codespace is created/started.
![Screenshot from 2024-01-26 19-53-21](https://github.com/r-devel/r-dev-env/assets/72031540/44bc9341-ef4b-47e9-9535-50f65bab3c99)

