### PR TITLE
temporarily use site library to set up VSCode-R ext

### DIFF
--- a/.RProfile
+++ b/.RProfile
@@ -1,0 +1,16 @@
+# Temporarily use site library to initialize VSCode-R extension.
+# This is where packages required by VSCode-R extension are installed, 
+# specifically jsonlite and rlang for R Session Watcher.
+# These are built and installed for the default R version when container is built.
+
+lp <- .libPaths() # already includes site library for default R version.
+.libPaths("/usr/local/lib/R/site-library")
+
+if (interactive() && Sys.getenv("RSTUDIO") == "") {
+  source(file.path(Sys.getenv(if (.Platform$OS.type == "windows") "USERPROFILE" else "HOME"), ".vscode-R", "init.R"))
+}
+
+options(vsc.dev.args = list(width = 800, height = 600))
+
+# Revert to vanilla .libPaths(), so built R only has base + recommended packages
+.libPaths(lp)

--- a/.RProfile
+++ b/.RProfile
@@ -1,16 +1,14 @@
-# Temporarily use site library to initialize VSCode-R extension.
-# This is where packages required by VSCode-R extension are installed, 
-# specifically jsonlite and rlang for R Session Watcher.
+# Set site library for full use of VSCode-R extension.
+# This is where packages required by VSCode-R extension are installed, specifically
+# - jsonlite and rlang for R Session Watcher (needed to open HTML help pages)
+# - languageserver for code completion
+# - httpgd for http graphics device
 # These are built and installed for the default R version when container is built.
 
-lp <- .libPaths() # already includes site library for default R version.
-.libPaths("/usr/local/lib/R/site-library")
+.Library.site <- "/usr/local/lib/R/site-library"
+# .libPaths() already includes site library for default R version.
+.libPaths(c(.libPaths(), .Library.site))
 
-if (interactive() && Sys.getenv("RSTUDIO") == "") {
-  source(file.path(Sys.getenv(if (.Platform$OS.type == "windows") "USERPROFILE" else "HOME"), ".vscode-R", "init.R"))
-}
-
-options(vsc.dev.args = list(width = 800, height = 600))
-
-# Revert to vanilla .libPaths(), so built R only has base + recommended packages
-.libPaths(lp)
+# For PNG graphics uncomment following lines
+# options(vsc.use_httpgd = FALSE,
+#         vsc.dev.args = list(width = 800, height = 600))

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ R-devel/
 R-devel.tar.gz
 /venv
 .cache/
+.Rproj.user


### PR DESCRIPTION
The VSCode-R extension checks for the jsonlite and rlang packages during initialization, so that the [R Session Watcher](https://github.com/REditorSupport/vscode-R/wiki/R-Session-watcher) will work. We install these packages when we install languageserver in the release version R that we add to the Docker container.

Although these packages only need to be available to the version of R used for background processes (defined by Rpath: Linux setting), the check is run on the version of R used in interactive sessions (defined by Rterm: Linux setting).

This PR adds an `.Rprofile` to temporarily add the library where the packages are installed to the library search path.

I have also set the options for the PNG graphics to a more sensible size - this may later be replaced by using httpgd graphics (https://github.com/r-devel/r-dev-env/issues/100#issue-2322672390).