### PR TITLE
docs: added rsync connection limit troubleshoot page to docs

### DIFF
--- a/docs/troubleshoot.md
+++ b/docs/troubleshoot.md
@@ -1,0 +1,15 @@
+While working with an R Dev Container, you may encounter some known errors. Here are a few common ones:
+
+1. #### Error: Rsync Connection Limit Reached, Preventing New Connections
+
+   **Description :** When attempting to use rsync, you may encounter the following error message:
+
+   ```
+   $TOP_SRCDIR/tools/rsync-recommended @ERROR: max connections (59) reached -- try again later rsync error: error starting client-server protocol (code 5) at main.c(1863) [Receiver=3.2.7] *** rsync failed to update Recommended files ***
+   ```
+   **Cause :** This error occurs because the rsync server has reached its maximum allowed number of simultaneous connections, which is set to 59. As a result, new connection attempts are rejected until some of the existing connections are closed.
+   
+   **Solutions :** 
+   1. Retry After Some Time :  Wait for a few minutes and try running the rsync command again. The number of active connections may decrease, allowing you to connect.
+   2. Restart Codespace : Sometimes, simply restarting your Codespace can resolve temporary connection issues. Try restarting your Codespace and then attempt the rsync command again.
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: R Devel Container Docs
 repo_name: r-devel/r-dev-env
 repo_url: https://github.com/r-devel/r-dev-env
 nav:
-    - 'Home': index.md
+    - 'Home': 'index.md'
     - 'Container Setup':
         - 'Starting Codespace': 'container_setup/creating_codespace.md'
         - 'Restarting and Stopping' : 'container_setup/codespacestartstop.md'
@@ -19,7 +19,8 @@ nav:
     - 'Contributor Guide' : 
         - 'contributor_guide/contributing_to_docs.md'
         - 'contributor_guide/contributing_to_codebase.md'
-    - 'Resources' : resources.md
+    - 'Resources' : 'resources.md'
+    - 'Troubleshooting Info' : 'troubleshoot.md'
 theme:
   name: material
   features:


### PR DESCRIPTION
Added troubleshoot section with rsync connection limit docs
PR for issue number : #139 