### PR TITLE
Fix for optimize-docs-images.yml

### DIFF
--- a/.github/workflows/optimize-docs-images.yml
+++ b/.github/workflows/optimize-docs-images.yml
@@ -22,11 +22,11 @@ jobs:
     - name: Install system dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y libmagick++-dev
+        sudo apt-get install -y libmagick++-dev libcurl4-openssl-dev
 
     - name: Install R packages
       run: |
-        R -e 'install.packages(c("magick", "tools"), repos = "https://cloud.r-project.org/")'
+        R -e 'install.packages(c("magick"), repos = "https://cloud.r-project.org/")'
 
     - name: Optimize images
       run: |


### PR DESCRIPTION
Added Curl as per
Configuration failed because libcurl was not found. Try installing:
 * deb: libcurl4-openssl-dev (Debian, Ubuntu, etc)

and removed "tools"  to satisfy error:
Warning messages:
1: package ‘tools’ is a base package, and should not be updated