### PR TITLE
install valgrind on top of gitpod/workspace-full

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -19,6 +19,7 @@ RUN sed -i.bak "/^#.*deb-src.*universe$/s/^# //g" /etc/apt/sources.list \
     && apt -y install subversion \
     && apt -y build-dep r-base-dev \
     && apt -y install r-base-dev \
+    && apt -y install valgrind \
     && Rscript -e "install.packages('languageserver', repos='https://cran.rstudio.com')" \
     && Rscript -e "install.packages('httpgd', repos='https://cran.rstudio.com')"
 


### PR DESCRIPTION
Valgrind does not seem to be part of gitpod/workspace-full, so updated .gitpod.Dockerfile to include this.

Should enable `$TOP_SRCDIR/configure --with-valgrind-instrumentation=1` to work.