### PR TITLE
use ppa:marutter/rrutter4.0 as base R repository

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -13,13 +13,15 @@ RUN if [ "${REINSTALL_CMAKE_VERSION_FROM_SOURCE}" != "none" ]; then \
     && rm -f /tmp/reinstall-cmake.sh
 
 RUN sed -i.bak "/^#.*deb-src.*universe$/s/^# //g" /etc/apt/sources.list \
-    && echo "deb https://cloud.r-project.org/bin/linux/ubuntu jammy-cran40/" >> /etc/apt/sources.list \
+    && apt -y update \
+    && apt install -y --no-install-recommends \
+      software-properties-common \
+      subversion \
+      valgrind \
+    && add-apt-repository --enable-source --yes "ppa:marutter/rrutter4.0" \
     && wget -qO- https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc | sudo tee -a /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc \
-    && apt update \
-    && apt -y install subversion \
     && apt -y build-dep r-base-dev \
     && apt -y install r-base-dev \
-    && apt -y install valgrind \
     && Rscript -e "install.packages('languageserver', repos='https://cran.rstudio.com')" \
     && Rscript -e "install.packages('httpgd', repos='https://cran.rstudio.com')"
 

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -23,7 +23,8 @@ RUN sed -i.bak "/^#.*deb-src.*universe$/s/^# //g" /etc/apt/sources.list \
     && apt -y build-dep r-base-dev \
     && apt -y install r-base-dev \
     && Rscript -e "install.packages('languageserver', repos='https://cran.rstudio.com')" \
-    && Rscript -e "install.packages('httpgd', repos='https://cran.rstudio.com')"
+    && Rscript -e "install.packages('httpgd', repos='https://cran.rstudio.com')" \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN apt install -y shellcheck
 RUN apt install -y ccache

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ RUN sed -i.bak "/^#.*deb-src.*universe$/s/^# //g" /etc/apt/sources.list \
     && apt -y build-dep r-base-dev \
     && apt -y install r-base-dev \
     && Rscript -e "install.packages('languageserver', repos='https://cran.rstudio.com')" \
-    && Rscript -e "install.packages('httpgd', repos='https://cran.rstudio.com')"
+    && Rscript -e "install.packages('httpgd', repos='https://cran.rstudio.com')" \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN apt install shellcheck
 RUN apt install -y ccache

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,12 @@ RUN if [ "${REINSTALL_CMAKE_VERSION_FROM_SOURCE}" != "none" ]; then \
     && rm -f /tmp/reinstall-cmake.sh
 
 RUN sed -i.bak "/^#.*deb-src.*universe$/s/^# //g" /etc/apt/sources.list \
-    && echo "deb https://cloud.r-project.org/bin/linux/ubuntu jammy-cran40/" >> /etc/apt/sources.list \
+    && apt -y update \
+    && apt install -y --no-install-recommends \
+      software-properties-common \
+      subversion \
+    && add-apt-repository --enable-source --yes "ppa:marutter/rrutter4.0" \
     && wget -qO- https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc | sudo tee -a /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc \
-    && apt update \
-    && apt -y install subversion \
     && apt -y build-dep r-base-dev \
     && apt -y install r-base-dev \
     && Rscript -e "install.packages('languageserver', repos='https://cran.rstudio.com')" \


### PR DESCRIPTION
This addresses part of #112, by updating the Dockerfiles to work on arm64 architecture.

The main fix is to use the "ppa:marutter/rrutter4.0" repository vs "https://cloud.r-project.org/bin/linux/ubuntu jammy-cran40/".