### PR TITLE
docs: Restrict copy-paste to input code

### DIFF
--- a/docs/contributor_guide/contributing_to_docs.md
+++ b/docs/contributor_guide/contributing_to_docs.md
@@ -7,24 +7,24 @@
 
 3. Create virtual environment using python venv
 ```
-python3 -m venv venv
+$ python3 -m venv venv
 ```
 
 4. Now activate the virtual environment 
 ```
-source ./venv/bin/activate
+$ source ./venv/bin/activate
 ```
 
 5. Now install libraries and dependencies for mkdocs
 ```
-pip install mkdocs "mkdocs-material[imaging]"
+$ pip install mkdocs "mkdocs-material[imaging]"
 ```
 
 6. After setting up the virtual environment and installing necessary libraries, navigate to the root directory of the project where the `mkdocs.yml` file is located.
 
 7. To start the local development server and preview changes, run the following command:
 ```
-mkdocs serve
+$ mkdocs serve
 ```
 This will compile the documentation and serve it locally. You can access the documentation by opening a web browser and navigating to http://localhost:8000.
 

--- a/docs/extra/js/setup_codeblocks.js
+++ b/docs/extra/js/setup_codeblocks.js
@@ -1,0 +1,108 @@
+const codeBlocks = [...document.querySelectorAll(".highlight > pre > code")];
+
+const rules = [
+    // shell commands
+    {
+        prefix: "$ ",
+        classes: ["code-noselect", "console-input"],
+    },
+    // comments
+    {
+        prefix: "# ",
+        plainText: true,
+        entireLine: true,
+        classes: ["code-noselect", "c1"],
+    },
+    // standard output
+    {
+        prefix: "<< ",
+        plainText: true,
+        entireLine: true,
+        deletePrefix: true,
+        classes: ["code-noselect", "console-output"],
+    },
+];
+
+const zip = (a, b) => a.map((k, i) => [k, b[i]]);
+
+// update code blocks with the mappings defined above
+codeBlocks.forEach((block) => {
+    let text = (block.textContent || "").split("\n");
+    let html = block.innerHTML.split("\n");
+    let lines = zip(text, html);
+
+    lines = lines.map((line) => {
+        const lineText = line[0];
+        const lineHtml = line[1];
+
+        const matches = rules.filter((rule) => lineText.startsWith(rule.prefix));
+
+        if (matches.length > 1) {
+            throw new Error("multiple rule matches");
+        }
+
+        if (matches.length === 1) {
+            const matchingRule = matches[0];
+            const classes = matchingRule.classes.join(" ");
+            let newContent;
+
+            if (matchingRule.plainText) {
+                newContent = lineText;
+            } else {
+                newContent = lineHtml;
+                newContent = newContent.replace(
+                    matchingRule.prefix.replace(" ", `<span class="w"> </span>`),
+                    matchingRule.prefix
+                );
+            }
+
+            if (matchingRule.entireLine) {
+                newContent = `<span class="${classes}">${newContent}</span>`;
+            } else {
+                newContent = newContent.replace(
+                    matchingRule.prefix,
+                    `<span class="${classes}">${matchingRule.prefix}</span>`
+                );
+            }
+
+            if (matchingRule.deletePrefix) {
+                newContent = newContent.replace(matchingRule.prefix, "");
+            }
+
+            return newContent;
+        } else {
+            return lineHtml;
+        }
+    });
+
+    block.innerHTML = lines.join("\n").trim();
+});
+
+// Update html attributes to remove elements with `code-noselect` when copying to clipboard
+window.addEventListener("load", () => {
+    const ids = document.querySelectorAll("*[data-clipboard-target]");
+    ids.forEach((id) => {
+        const attr = id.getAttribute("data-clipboard-target");
+        if (!attr) {
+            return;
+        }
+        const node = document.querySelector(attr);
+        if (!node) {
+            return;
+        }
+        let text = [];
+        node.childNodes.forEach((child) => {
+            if (child.nodeName === "#text") {
+                text.push(child.textContent || "");
+            } else if (!child.classList.contains("code-noselect")) {
+                text.push(child.innerText);
+            }
+        });
+        let joinedText = text.join("");
+        id.setAttribute(
+            "data-clipboard-text",
+            joinedText.trim().replace(/(?:\h*\n){2,}/g, "\n")
+        );
+        id.removeAttribute("data-clipboard-target");
+    });
+});

--- a/docs/extra/stylesheets/codeblocks.css
+++ b/docs/extra/stylesheets/codeblocks.css
@@ -1,0 +1,11 @@
+.code-noselect {
+    user-select: none;
+}
+
+.console-input {
+    color: var(--md-primary-fg-color);
+}
+
+.console-output {
+    color: var(--md-default-fg-color--light);
+}

--- a/docs/troubleshoot.md
+++ b/docs/troubleshoot.md
@@ -5,7 +5,10 @@ While working with an R Dev Container, you may encounter some known errors. Here
     **Description :** When attempting to use rsync, you may encounter the following error message:
 
     ```
-    $TOP_SRCDIR/tools/rsync-recommended @ERROR: max connections (59) reached -- try again later rsync error: error starting client-server protocol (code 5) at main.c(1863) [Receiver=3.2.7] *** rsync failed to update Recommended files ***
+    $ $TOP_SRCDIR/tools/rsync-recommended
+    << @ERROR: max connections (59) reached -- try again later
+    << rsync error: error starting client-server protocol (code 5) at main.c(1863) [Receiver=3.2.7]
+    << *** rsync failed to update Recommended files ***
     ```
     **Cause :** This error occurs because the rsync server has reached its maximum allowed number of simultaneous connections, which is set to 59. As a result, new connection attempts are rejected until some of the existing connections are closed.
    

--- a/docs/tutorials/building_r.md
+++ b/docs/tutorials/building_r.md
@@ -12,7 +12,7 @@
 - The svn checkout command lets us create a local copy of a specific tag/branch of a repository.
 - We can check out the latest version of the trunk (the main branch) of the R sources to $TOP_SRCDIR as follows:
     ```bash
-    svn checkout https://svn.r-project.org/R/trunk/ $TOP_SRCDIR
+    $ svn checkout https://svn.r-project.org/R/trunk/ $TOP_SRCDIR
     ```
 - Output : We get file structure something like this after checking out R source code from R svn repository.
 
@@ -22,7 +22,7 @@
 
 To build R with the recommended packages, we need to run the `tools/rsync-recommended` script from the source directory to download the source code for these packages:
 ```bash
-$TOP_SRCDIR/tools/rsync-recommended
+$ $TOP_SRCDIR/tools/rsync-recommended
 ```
 ![alt text](../assets/rdev9.png)
 
@@ -32,12 +32,12 @@ $TOP_SRCDIR/tools/rsync-recommended
 
 - First create the directory specified by the BUILDDIR environment variable.
 ```bash
-mkdir -p $BUILDDIR
+$ mkdir -p $BUILDDIR
 ```
 
 - Then we can change directory from root to the build directory.
 ```bash
-cd $BUILDDIR
+$ cd $BUILDDIR
 ```
 
 **5) Configure the build**
@@ -45,7 +45,7 @@ cd $BUILDDIR
 - After we change directory, we must run the configure script from the source directory.
 This step takes ~1 minute on the codespace.
 ```bash
-$TOP_SRCDIR/configure --with-valgrind-instrumentation=1
+$ $TOP_SRCDIR/configure --with-valgrind-instrumentation=1
 
 ```
 
@@ -61,28 +61,26 @@ $TOP_SRCDIR/configure --with-valgrind-instrumentation=1
 
 Having configured R, we run `make` to build R. This take 5-10 minutes on the codespace.
 ```bash
-make
+$ make
 ```
 **7) Check R**
 
 Check that the build of R passes R's standard checks:
 ```bash
-make check
+$ make check
 ```
 This takes a couple of minutes in the codespace. The check will stop with a error message if any of the tests fail. If this happens, see [SVN Help](./svn_help.md) for how to revert to a version that passes check.
 
 **8) Make R terminals use the built R**
 
 Run the `which_r` script to set which R to use for R terminals in VSCode. When prompted, enter the number corresponding to `r-devel`
-```
-which_r
-```
-```
-Which version of R should be used in new R terminals?
-  1. R 4.4.0 (release version built into this container)
-  Additional R builds available:
-    2. r-devel
-Enter the number corresponding to the selected version: 
+```bash
+$ which_r
+<< Which version of R should be used in new R terminals?
+<<   1. R 4.4.0 (release version built into this container)
+<<   Additional R builds available:
+<<     2. r-devel
+<< Enter the number corresponding to the selected version: 
 ```
 This means that new R terminals will use the version of R you have just built![^1]
 

--- a/docs/tutorials/contribution_workflow.md
+++ b/docs/tutorials/contribution_workflow.md
@@ -19,7 +19,7 @@
 - Edit the source code of `utils::askYesNo()` to change the default options. The source code can be found in `$TOP_SRCDIR/src/library/utils/R/askYesNo.R`.
 - You can redirect to that file using 
 ``` 
-code $TOP_SRCDIR/src/library/utils/R/askYesNo.R
+$ code $TOP_SRCDIR/src/library/utils/R/askYesNo.R
 ```
 
 **> Before edit:**
@@ -44,11 +44,11 @@ code $TOP_SRCDIR/src/library/utils/R/askYesNo.R
 - Quit R with `q()` or by closing the R terminal.
 - In the bash terminal, change to the build directory:
 ```bash
-cd $BUILDDIR
+$ cd $BUILDDIR
 ```
 -  Now run the `make` command to rebuild R with the changes you made in step 2. This will be much faster than the full build!
 ```bash
-make
+$ make
 ```
     
 ![alt text](../assets/rdev22.png)

--- a/docs/tutorials/multi_r_compilation.md
+++ b/docs/tutorials/multi_r_compilation.md
@@ -23,17 +23,12 @@ You can build multiple R versions in the same Codespaces environment.
 
     -   Open a terminal in the codespace.
 
-    -   Run the `set_build_r` function with your chosen name as the argument, e.g.
+    -   Run the `set_build_r` function with your chosen name as the argument. The new values of the environment variables will then be printed as confirmation, e.g.
 
         ```         
-        set_build_r r-devel-raw
-        ```
-
-        The new values of the environment variables will be printed as confirmation:
-
-        ```         
-        BUILDDIR is now set to /workspaces/r-dev-env/build/r-devel-raw
-        TOP_SRCDIR is now set to /workspaces/r-dev-env/svn/r-devel-raw
+        $ set_build_r r-devel-raw
+        << BUILDDIR is now set to /workspaces/r-dev-env/build/r-devel-raw
+        << TOP_SRCDIR is now set to /workspaces/r-dev-env/svn/r-devel-raw
         ```
         
 3.  If you have an unmodified build of R-devel using the default name of
@@ -41,8 +36,8 @@ You can build multiple R versions in the same Codespaces environment.
     directories with `rsync`:
 
     ```         
-    rsync -a "$(dirname "$BUILDDIR")/r-devel/"* $BUILDDIR
-    rsync -a "$(dirname "$TOP_SRCDIR")/r-devel/"* $TOP_SRCDIR
+    $ rsync -a "$(dirname "$BUILDDIR")/r-devel/"* $BUILDDIR
+    $ rsync -a "$(dirname "$TOP_SRCDIR")/r-devel/"* $TOP_SRCDIR
     ```
 
     Otherwise you can follow the steps in the [Building R](./building_r.md)
@@ -53,17 +48,14 @@ You can build multiple R versions in the same Codespaces environment.
     see your chosen name in the choices when running the `which_r` script to 
     select the version of R to run in new terminals, e.g.
 
-    ```         
-    which_r
-    ```
-
-    ```  
-    Which version of R should be used in new R terminals?
-      1. R 4.4.0 (release version built into this container)
-      Additional R builds available:
-        2. r-devel
-        3. r-devel-raw
-    Enter the number corresponding to the selected version: 
+    ```bash
+    $ which_r
+    << Which version of R should be used in new R terminals?
+    <<   1. R 4.4.0 (release version built into this container)
+    <<   Additional R builds available:
+    <<     2. r-devel
+    <<     3. r-devel-raw
+    << Enter the number corresponding to the selected version: 
     ```
 
 !!! Note
@@ -77,8 +69,8 @@ You can build multiple R versions in the same Codespaces environment.
     You can check the values any time with 
     
     ```
-    echo $BUILDDIR
-    echo $TOP_SRCDIR
+    $ echo $BUILDDIR
+    $ echo $TOP_SRCDIR
     ```
     
     and switch with `set_build_r <name>`.

--- a/docs/tutorials/patch_update.md
+++ b/docs/tutorials/patch_update.md
@@ -11,12 +11,12 @@ If you have not recently updated your local copy of the R Subversion repository,
 Go to the source directory and use `svn diff` to create a patch. 
 
 ```bash
-cd $TOP_SRCDIR
-svn diff > $PATCHDIR/patch.diff
+$ cd $TOP_SRCDIR
+$ svn diff > $PATCHDIR/patch.diff
 ```
 
 The patch file will be saved in the directory specified by the PATCHDIR environment variable that is defined when the codespace starts
 
 ```bash
-echo $PATCHDIR/patch.diff
+$ echo $PATCHDIR/patch.diff
 ```

--- a/docs/tutorials/running_r.md
+++ b/docs/tutorials/running_r.md
@@ -1,7 +1,7 @@
 
 1) Create a file in VS Code ending with a .R extension. You can create new files by clicking on the new file icon in VS Code Explorer, or use the `code` command in the terminal to create and open an R file
 ```bash
-code R/test.R
+$ code R/test.R
 ```
 
 ![alt text](../assets/rdev4.png)

--- a/docs/tutorials/svn_help.md
+++ b/docs/tutorials/svn_help.md
@@ -3,7 +3,7 @@
 You can check out a specific revision of the R sources with
 
 ```bash
-svn checkout -r 1234 https://svn.r-project.org/R/trunk/ $TOP_SRCDIR
+$ svn checkout -r 1234 https://svn.r-project.org/R/trunk/ $TOP_SRCDIR
 ```
 
 ### Finding the last revision that passed check
@@ -16,31 +16,29 @@ Find the latest run that completed successfully (green checkmark) and use the co
 For example, to search the last 10 revisions for the log message "More @apifun and such annotations"
 
 ```bash
-cd $TOP_SRCDIR
-svn log --limit 10 --search "More @apifun and such annotations"
-```
-```
-/workspaces/r-dev-env/svn/r-devel $ svn log --limit 10 --search "More @apifun and such annotations"
-------------------------------------------------------------------------
-r86726 | luke | 2024-06-12 18:00:19 +0000 (Wed, 12 Jun 2024) | 2 lines
-
-More @apifun and such annotations.
-
-------------------------------------------------------------------------
-r86723 | luke | 2024-06-11 20:31:36 +0000 (Tue, 11 Jun 2024) | 2 lines
-
-More @apifun and such annotations.
-
-------------------------------------------------------------------------
+$ cd $TOP_SRCDIR
+$ svn log --limit 10 --search "More @apifun and such annotations"
+<< /workspaces/r-dev-env/svn/r-devel $ svn log --limit 10 --search "More @apifun and such annotations"
+<< ------------------------------------------------------------------------
+<< r86726 | luke | 2024-06-12 18:00:19 +0000 (Wed, 12 Jun 2024) | 2 lines
+<< 
+<< More @apifun and such annotations.
+<< 
+<< ------------------------------------------------------------------------
+<< r86723 | luke | 2024-06-11 20:31:36 +0000 (Tue, 11 Jun 2024) | 2 lines
+<< 
+<< More @apifun and such annotations.
+<< 
+<< ------------------------------------------------------------------------
 ```
 
 If you have already attempted to build R, you can re-run the make with the version identified in your search as follows:
 
 ```
-svn checkout -r 86726 https://svn.r-project.org/R/trunk/ $TOP_SRCDIR
-cd $BUILDDIR
-make
-make check
+$ svn checkout -r 86726 https://svn.r-project.org/R/trunk/ $TOP_SRCDIR
+$ cd $BUILDDIR
+$ make
+$ make check
 ```
 
 Otherwise, follow the full instructions in [Building R](./building_r.md), updating the svn checkout command to use the required revision.

--- a/docs/tutorials/update_source.md
+++ b/docs/tutorials/update_source.md
@@ -9,7 +9,7 @@ If you have an R terminal open, quit R or close the terminal.
 In a bash terminal, change to the source directory
 
 ```bash
-cd $TOP_SRCDIR
+$ cd $TOP_SRCDIR
 ```
 
 #### 3) Review local changes
@@ -17,7 +17,7 @@ cd $TOP_SRCDIR
 Use the Subversion diff command to review changes you have made to source code
 
 ```bash
-svn diff
+$ svn diff
 ```
 
 #### 4) Revert changes (optional)
@@ -27,18 +27,18 @@ If you no longer want to keep your local changes, you can revert them.
 Revert the changes made in specific file
 
 ```bash
-svn revert src/library/utils/R/askYesNo.R
+$ svn revert src/library/utils/R/askYesNo.R
 ```
 Revert changes in a directory
 
 ```bash
-svn revert src/lib/utils
+$ svn revert src/lib/utils
 ```
 
 Revert all local changes
 
 ```bash
-svn revert -R .
+$ svn revert -R .
 ```
 
 #### 5) Rebuild and check with any local changes
@@ -48,15 +48,15 @@ If you have no local changes remaining, skip to the next step.
 Otherwise, go to the build directory to build and check R with your local changes.
 
 ```bash
-cd $BUILDDIR
-make
-make check
+$ cd $BUILDDIR
+$ make
+$ make check
 ```
 
 If the check fails with an error, you have broken something with your local changes. Fix this before proceeding. Otherwise go back to the source directory to continue
 
 ```bash
-cd $TOP_SRCDIR
+$ cd $TOP_SRCDIR
 ```
 
 #### 6) Update using svn
@@ -64,7 +64,7 @@ cd $TOP_SRCDIR
 Use the Subversion command `update` to update your local copy with the latest changes by the R Core Team.
 
 ```bash
-svn update
+$ svn update
 ```
 
 #### 7)  Rebuild and check with the updates
@@ -72,9 +72,9 @@ svn update
 To rebuild R with the latest changes from the R Core Team and any local changes you have kept, go to the build directory to build and check R
 
 ```bash
-cd $BUILDDIR
-make 
-make check
+$ cd $BUILDDIR
+$ make 
+$ make check
 ```
 
 If the check fails, this will be due to recent changes made by the R Core Team. See [SVN Help](./svn_help.md) for how to revert to a version that passes check.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,3 +79,10 @@ markdown_extensions:
   - pymdownx.superfences
   - pymdownx.mark
   - attr_list
+
+extra_css:
+  - extra/stylesheets/codeblocks.css
+
+extra_javascript:
+  - extra/js/setup_codeblocks.js
+


### PR DESCRIPTION
Resolves #106 

This PR attempts to follow [the method](https://github.com/squidfunk/mkdocs-material/discussions/3427#discussioncomment-5527538) mentioned in the linked issue to support restricting copy-pasting of content inside code blocks (i.e. inside ` ``` `) to just input code in the following manner:

- Lines starting with the prefix `$ ` are considered to be "input lines". They can be copied.
- Lines starting with the prefix `<< ` ("output lines") or `# ` ("comment lines") are neither copied using the copy button, nor can they be selected by the user.

Also, the prefixes (`$ `, `<< `, `# `) themselves cannot be copied or selected.


## Screenshots

This is what one of the changes looks like:

| **Before**                                  | **After**                                   |
|---------------------------------------------|---------------------------------------------|
| ![image](https://github.com/user-attachments/assets/da4f4be9-a2d2-43ea-bd82-a7d87064ae75)   | ![image](https://github.com/user-attachments/assets/1b557466-df55-40ca-a3d5-eaedab720dcd)     |

Behaviour of the copy-to-clipboard button:

https://github.com/user-attachments/assets/4838c6da-c8e2-4c8a-816f-f637ff2af9c4


