### PR TITLE
docs: Use proper code fencing for console outputs

### DIFF
--- a/docs/container_setup/github_codespace/creating_codespace.md
+++ b/docs/container_setup/github_codespace/creating_codespace.md
@@ -10,12 +10,12 @@ Follow these steps to create a new codespace for R development:
 
 !!! Note "About Codespace Billing"
     You will see the message "Codespace usage for this repository is paid for by [your username]". Don't worry!
-    
+
     - GitHub Codespaces offers 120 core hours of free usage per month for every GitHub user
     - The actual free hours = 120 / number of cores used
     - The r-dev-env codespace uses 4 cores by default = 30 hours free usage per month
     - You can adjust the core count based on your needs
-    
+
     **Useful Resources:**
     - [Codespaces Billing Documentation](https://github.com/features/codespaces)
     - [GitHub Services Pricing Calculator](https://github.com/pricing/calculator)

--- a/docs/container_setup/github_codespace/creating_codespace.md
+++ b/docs/container_setup/github_codespace/creating_codespace.md
@@ -1,21 +1,29 @@
+# Creating a GitHub Codespace
 
-1. From the main branch of the [r-dev-env
-repo](https://github.com/r-devel/r-dev-env/tree/main), click on the 'Open in
-GitHub Codespaces' button and then click the green 'Create Codespace' button.
+Follow these steps to create a new codespace for R development:
+
+1. Navigate to the [r-dev-env repo](https://github.com/r-devel/r-dev-env/tree/main) main branch
+2. Click the 'Open in GitHub Codespaces' button
+3. Click the green 'Create Codespace' button
+
 ![create codespace](../../assets/rdev1.png)
 
-    !!! Note You will see the message "Codespace usage for this repository is
-        paid for by ...", with your username. Don't panic!
+!!! Note "About Codespace Billing"
+    You will see the message "Codespace usage for this repository is paid for by [your username]". Don't worry!
+    
+    - GitHub Codespaces offers 120 core hours of free usage per month for every GitHub user
+    - The actual free hours = 120 / number of cores used
+    - The r-dev-env codespace uses 4 cores by default = 30 hours free usage per month
+    - You can adjust the core count based on your needs
+    
+    **Useful Resources:**
+    - [Codespaces Billing Documentation](https://github.com/features/codespaces)
+    - [GitHub Services Pricing Calculator](https://github.com/pricing/calculator)
+    - [Your GitHub Billing Page](https://github.com/settings/billing) (check "Codespaces" section)
 
-        GitHub Codespaces offers 120 core hours of free usage per month for every GitHub user. So the actual number of free hours is 120 divided by the number of cores you are using to run your codespaces.
-        For the r-dev-env codespace we have set the codespace usage to 4 cores which leads to 30hrs of free usage per month. This can be changed according to your preference.
+## Setting Up Your Environment
 
-        For more details about codespaces billing, see the [Codespaces Billing Docs](https://github.com/features/codespaces).
-        You can calculate your GitHub services usage with the [GitHub Services
-        Pricing Calculator](https://github.com/pricing/calculator) and check your usage allowance under "Codespaces" on your [GitHub Billing page](https://github.com/settings/billing).
+1. Wait for the codespace setup screen to complete (about 1 minute)
+2. You'll be redirected to VSCode in your browser:
 
-2. The codespace setup screen will then be shown. Starting the container may
-   take a minute or so.
-
-3. You will be taken to a VSCode editor within your browser.
 ![codespace](../../assets/rdev3.png)

--- a/docs/container_setup/github_codespace/creating_codespace.md
+++ b/docs/container_setup/github_codespace/creating_codespace.md
@@ -11,12 +11,12 @@ Follow these steps to create a new codespace:
 !!! Note "About Codespace Billing"
     You will see "Codespace usage for this repository is paid for by [user]".
     Don't worry!
-    
+
     - GitHub Codespaces: 120 core hours free per month
     - Free hours = 120 / number of cores
     - Default: 4 cores = 30 hours free per month
     - Core count can be adjusted
-    
+
     **Resources:**
     - [Billing Docs](https://github.com/features/codespaces)
     - [Pricing Calculator](https://github.com/pricing/calculator)

--- a/docs/container_setup/github_codespace/creating_codespace.md
+++ b/docs/container_setup/github_codespace/creating_codespace.md
@@ -1,29 +1,30 @@
 # Creating a GitHub Codespace
 
-Follow these steps to create a new codespace for R development:
+Follow these steps to create a new codespace:
 
-1. Navigate to the [r-dev-env repo](https://github.com/r-devel/r-dev-env/tree/main) main branch
-2. Click the 'Open in GitHub Codespaces' button
-3. Click the green 'Create Codespace' button
+1. Navigate to the [r-dev-env repo](https://github.com/r-devel/r-dev-env)
+2. Click 'Open in GitHub Codespaces'
+3. Click 'Create Codespace'
 
 ![create codespace](../../assets/rdev1.png)
 
 !!! Note "About Codespace Billing"
-    You will see the message "Codespace usage for this repository is paid for by [your username]". Don't worry!
+    You will see "Codespace usage for this repository is paid for by [user]".
+    Don't worry!
+    
+    - GitHub Codespaces: 120 core hours free per month
+    - Free hours = 120 / number of cores
+    - Default: 4 cores = 30 hours free per month
+    - Core count can be adjusted
+    
+    **Resources:**
+    - [Billing Docs](https://github.com/features/codespaces)
+    - [Pricing Calculator](https://github.com/pricing/calculator)
+    - [Billing Page](https://github.com/settings/billing)
 
-    - GitHub Codespaces offers 120 core hours of free usage per month for every GitHub user
-    - The actual free hours = 120 / number of cores used
-    - The r-dev-env codespace uses 4 cores by default = 30 hours free usage per month
-    - You can adjust the core count based on your needs
+## Setup
 
-    **Useful Resources:**
-    - [Codespaces Billing Documentation](https://github.com/features/codespaces)
-    - [GitHub Services Pricing Calculator](https://github.com/pricing/calculator)
-    - [Your GitHub Billing Page](https://github.com/settings/billing) (check "Codespaces" section)
-
-## Setting Up Your Environment
-
-1. Wait for the codespace setup screen to complete (about 1 minute)
-2. You'll be redirected to VSCode in your browser:
+1. Wait for codespace setup (about 1 minute)
+2. You'll be redirected to VSCode:
 
 ![codespace](../../assets/rdev3.png)

--- a/docs/tutorials/building_r.md
+++ b/docs/tutorials/building_r.md
@@ -9,7 +9,11 @@ The following environment variables define paths for building R:
 
 These variables are set in the codespace image and available at startup.
 
+ 
+
 ![alt text](../assets/rdev6.png)
+
+ 
 
 ## 2. SVN Checkout
 
@@ -19,9 +23,15 @@ Get a local copy of R source code from the repository:
 svn checkout https://svn.r-project.org/R/trunk/ $TOP_SRCDIR
 ```
 
+ 
+
 After checkout, you'll see:
 
+ 
+
 ![alt text](../assets/rdev8.png)
+
+ 
 
 ## 3. Download Packages
 
@@ -31,7 +41,11 @@ Get recommended packages:
 $TOP_SRCDIR/tools/rsync-recommended
 ```
 
+ 
+
 ![alt text](../assets/rdev9.png)
+
+ 
 
 ## 4. Set Up Build Directory
 
@@ -49,6 +63,8 @@ Keep source directory clean by using a separate build directory:
    cd $BUILDDIR
    ```
 
+ 
+
 ## 5. Configure the Build
 
 Run configure (~1 minute):
@@ -57,14 +73,22 @@ Run configure (~1 minute):
 $TOP_SRCDIR/configure --with-valgrind-instrumentation=1
 ```
 
+ 
+
 !!! Note
     The `--with-valgrind-instrumentation` option enables effective use of
     valgrind. See the [docs](https://cran.r-project.org/doc/manuals/R-exts.html#Using-valgrind)
     for details.
 
+ 
+
 After configuration:
 
+ 
+
 ![alt text](../assets/rdev7.png)
+
+ 
 
 ## 6. Build R
 
@@ -74,6 +98,8 @@ Build R (5-10 minutes):
 make
 ```
 
+ 
+
 ## 7. Run Tests
 
 Run standard tests:
@@ -82,7 +108,11 @@ Run standard tests:
 make check
 ```
 
+ 
+
 If tests fail, see [SVN Help](./svn_help.md).
+
+ 
 
 ## 8. Configure R Terminal
 
@@ -91,6 +121,8 @@ Set R version for VSCode:
 ```bash
 which_r
 ```
+
+ 
 
 You'll see:
 
@@ -102,10 +134,14 @@ Additional R builds available:
 Enter the number corresponding to the selected version:
 ```
 
+ 
+
 Select `r-devel` to use your built version.[^1]
 
 [^1]: To switch back to release version, run `which_r` and select `1`.
     Selection persists across restarts.
+
+ 
 
 ## 9. Next Steps
 

--- a/docs/tutorials/building_r.md
+++ b/docs/tutorials/building_r.md
@@ -9,11 +9,7 @@ The following environment variables define paths for building R:
 
 These variables are set in the codespace image and available at startup.
 
- 
-
 ![alt text](../assets/rdev6.png)
-
- 
 
 ## 2. SVN Checkout
 
@@ -23,15 +19,9 @@ Get a local copy of R source code from the repository:
 svn checkout https://svn.r-project.org/R/trunk/ $TOP_SRCDIR
 ```
 
- 
-
 After checkout, you'll see:
 
- 
-
 ![alt text](../assets/rdev8.png)
-
- 
 
 ## 3. Download Packages
 
@@ -41,11 +31,7 @@ Get recommended packages:
 $TOP_SRCDIR/tools/rsync-recommended
 ```
 
- 
-
 ![alt text](../assets/rdev9.png)
-
- 
 
 ## 4. Set Up Build Directory
 
@@ -63,8 +49,6 @@ Keep source directory clean by using a separate build directory:
    cd $BUILDDIR
    ```
 
- 
-
 ## 5. Configure the Build
 
 Run configure (~1 minute):
@@ -73,22 +57,14 @@ Run configure (~1 minute):
 $TOP_SRCDIR/configure --with-valgrind-instrumentation=1
 ```
 
- 
-
 !!! Note
     The `--with-valgrind-instrumentation` option enables effective use of
     valgrind. See the [docs](https://cran.r-project.org/doc/manuals/R-exts.html#Using-valgrind)
     for details.
 
- 
-
 After configuration:
 
- 
-
 ![alt text](../assets/rdev7.png)
-
- 
 
 ## 6. Build R
 
@@ -98,8 +74,6 @@ Build R (5-10 minutes):
 make
 ```
 
- 
-
 ## 7. Run Tests
 
 Run standard tests:
@@ -108,11 +82,7 @@ Run standard tests:
 make check
 ```
 
- 
-
 If tests fail, see [SVN Help](./svn_help.md).
-
- 
 
 ## 8. Configure R Terminal
 
@@ -121,8 +91,6 @@ Set R version for VSCode:
 ```bash
 which_r
 ```
-
- 
 
 You'll see:
 
@@ -134,14 +102,10 @@ Additional R builds available:
 Enter the number corresponding to the selected version:
 ```
 
- 
-
 Select `r-devel` to use your built version.[^1]
 
 [^1]: To switch back to release version, run `which_r` and select `1`.
     Selection persists across restarts.
-
- 
 
 ## 9. Next Steps
 

--- a/docs/tutorials/building_r.md
+++ b/docs/tutorials/building_r.md
@@ -2,32 +2,30 @@
 
 ## 1. Environment Variables
 
-The following environment variables define important paths for building R:
+The following environment variables define paths for building R:
 
-- `BUILDDIR`: Build directory location at `/workspaces/r-dev-env/build/r-devel`
-- `TOP_SRCDIR`: Source directory location at `/workspaces/r-dev-env/svn/r-devel`
+- `BUILDDIR`: `/workspaces/r-dev-env/build/r-devel`
+- `TOP_SRCDIR`: `/workspaces/r-dev-env/svn/r-devel`
 
-These environment variables are set in the codespace image and are available
-when the codespace starts.
+These variables are set in the codespace image and available at startup.
 
 ![alt text](../assets/rdev6.png)
 
 ## 2. SVN Checkout
 
-The SVN checkout command creates a local copy of a specific tag/branch from the R repository.
-To check out the latest version of the trunk (main branch) of the R sources to `$TOP_SRCDIR`:
+Get a local copy of R source code from the repository:
 
 ```bash
 svn checkout https://svn.r-project.org/R/trunk/ $TOP_SRCDIR
 ```
 
-After checking out, you'll see a file structure like this:
+After checkout, you'll see:
 
 ![alt text](../assets/rdev8.png)
 
-## 3. Download Recommended Packages
+## 3. Download Packages
 
-To build R with the recommended packages, run the `tools/rsync-recommended` script from the source directory:
+Get recommended packages:
 
 ```bash
 $TOP_SRCDIR/tools/rsync-recommended
@@ -37,17 +35,15 @@ $TOP_SRCDIR/tools/rsync-recommended
 
 ## 4. Set Up Build Directory
 
-To keep the source directory clean, we'll use a separate build directory:
+Keep source directory clean by using a separate build directory:
 
-1. Create the build directory:
-
+1. Create build directory:
 
    ```bash
    mkdir -p $BUILDDIR
    ```
 
-
-2. Change to the build directory:
+2. Change to build directory:
 
    ```bash
    cd $BUILDDIR
@@ -55,24 +51,24 @@ To keep the source directory clean, we'll use a separate build directory:
 
 ## 5. Configure the Build
 
-Run the configure script from the source directory (~1 minute on codespace):
+Run configure (~1 minute):
 
 ```bash
 $TOP_SRCDIR/configure --with-valgrind-instrumentation=1
 ```
 
 !!! Note
-    The `--with-valgrind-instrumentation` option is set to 1 for effective use
-    of valgrind. See the [Using valgrind](https://cran.r-project.org/doc/manuals/R-exts.html#Using-valgrind)
-    section of the R-admin manual for more information.
+    The `--with-valgrind-instrumentation` option enables effective use of
+    valgrind. See the [docs](https://cran.r-project.org/doc/manuals/R-exts.html#Using-valgrind)
+    for details.
 
-After configuration, you'll see a file structure like this:
+After configuration:
 
 ![alt text](../assets/rdev7.png)
 
 ## 6. Build R
 
-Run `make` to build R (5-10 minutes on codespace):
+Build R (5-10 minutes):
 
 ```bash
 make
@@ -80,38 +76,37 @@ make
 
 ## 7. Run Tests
 
-Check that the build passes R's standard tests:
+Run standard tests:
 
 ```bash
 make check
 ```
 
-This takes a couple of minutes. If any tests fail, see [SVN Help](./svn_help.md) for how to revert to a working version.
+If tests fail, see [SVN Help](./svn_help.md).
 
 ## 8. Configure R Terminal
 
-Run `which_r` to set which R version to use in VSCode's R terminals:
+Set R version for VSCode:
 
 ```bash
 which_r
 ```
 
+You'll see:
 
-You'll see this prompt:
-
-```
+```text
 Which version of R should be used in new R terminals?
-  1. R 4.4.0 (release version built into this container)
-  Additional R builds available:
-    2. r-devel
+1. R 4.4.0 (release version built into this container)
+Additional R builds available:
+  2. r-devel
 Enter the number corresponding to the selected version:
 ```
 
-Select the number for `r-devel`. New R terminals will now use your newly built version.[^1]
+Select `r-devel` to use your built version.[^1]
 
-[^1]: To switch back to the release version, run `which_r` and select `1`. Your selection is saved in VSCode settings and persists across codespace restarts.
+[^1]: To switch back to release version, run `which_r` and select `1`.
+    Selection persists across restarts.
 
 ## 9. Next Steps
 
-Now that you've built the development version of R, you can start contributing to the project.
-Follow the [R Contribution Workflow](./contribution_workflow.md) tutorial to learn how.
+Start contributing! Follow the [R Contribution Workflow](./contribution_workflow.md).

--- a/docs/tutorials/building_r.md
+++ b/docs/tutorials/building_r.md
@@ -1,36 +1,33 @@
-<!-- markdownlint-disable MD036 -->
-**1) Environment variables**
+# Building R from Source
 
-- We have environment variables defining paths to directories for building R and
-  storing the source code.
-- `BUILDDIR` defines the build directory: `/workspaces/r-dev-env/build/r-devel`.
-- `TOP_SRCDIR` defines the source directory: `/workspaces/r-dev-env/svn/r-devel`
-- The environment variables are set in the codespace image and are available
-  when the codespace starts.
+## 1. Environment Variables
 
-    ![alt text](../assets/rdev6.png)
+The following environment variables define important paths for building R:
 
-**2) svn checkout**
+- `BUILDDIR`: Build directory location at `/workspaces/r-dev-env/build/r-devel`
+- `TOP_SRCDIR`: Source directory location at `/workspaces/r-dev-env/svn/r-devel`
 
-- The svn checkout command lets us create a local copy of a specific tag/branch
-  of a repository.
-- We can check out the latest version of the trunk (the main branch) of the R
-  sources to $TOP_SRCDIR as follows:
+These environment variables are set in the codespace image and are available
+when the codespace starts.
 
-    ```bash
-    svn checkout https://svn.r-project.org/R/trunk/ $TOP_SRCDIR
-    ```
+![alt text](../assets/rdev6.png)
 
-- Output : We get file structure something like this after checking out R source
-  code from R svn repository.
+## 2. SVN Checkout
 
-    ![alt text](../assets/rdev8.png)
+The SVN checkout command creates a local copy of a specific tag/branch from the R repository.
+To check out the latest version of the trunk (main branch) of the R sources to `$TOP_SRCDIR`:
 
-**3) Download recommended packages for R**
+```bash
+svn checkout https://svn.r-project.org/R/trunk/ $TOP_SRCDIR
+```
 
-To build R with the recommended packages, we need to run the
-`tools/rsync-recommended` script from the source directory to download the
-source code for these packages:
+After checking out, you'll see a file structure like this:
+
+![alt text](../assets/rdev8.png)
+
+## 3. Download Recommended Packages
+
+To build R with the recommended packages, run the `tools/rsync-recommended` script from the source directory:
 
 ```bash
 $TOP_SRCDIR/tools/rsync-recommended
@@ -38,79 +35,65 @@ $TOP_SRCDIR/tools/rsync-recommended
 
 ![alt text](../assets/rdev9.png)
 
-**4) Change to the build directory**
+## 4. Set Up Build Directory
 
-- To keep the source directory clean, we change to a build directory to
-  configure and build R.
+To keep the source directory clean, we'll use a separate build directory:
 
-- First create the directory specified by the BUILDDIR environment variable.
+1. Create the build directory:
+   ```bash
+   mkdir -p $BUILDDIR
+   ```
 
-```bash
-mkdir -p $BUILDDIR
-```
+2. Change to the build directory:
+   ```bash
+   cd $BUILDDIR
+   ```
 
-- Then we can change directory from root to the build directory.
+## 5. Configure the Build
 
-```bash
-cd $BUILDDIR
-```
-
-**5) Configure the build**
-
-- After we change directory, we must run the configure script from the source
-directory.  This step takes ~1 minute on the codespace.
+Run the configure script from the source directory (~1 minute on codespace):
 
 ```bash
 $TOP_SRCDIR/configure --with-valgrind-instrumentation=1
-
 ```
 
-<!-- markdownlint-disable MD046 -->
 !!! Note
     The `--with-valgrind-instrumentation` option is set to 1 for effective use
-    of valgrind. See the [Using
-    valgrind](https://cran.r-project.org/doc/manuals/R-exts.html#Using-valgrind)
+    of valgrind. See the [Using valgrind](https://cran.r-project.org/doc/manuals/R-exts.html#Using-valgrind)
     section of the R-admin manual for more information.
-<!-- markdownlint-enable MD046 -->
 
-- The configure cmd prepares for building R, creating files and folders inside
-  the BUILDDIR directory.
-- Output : We get file structure something like this after using configure
-  command.
+After configuration, you'll see a file structure like this:
 
-    ![alt text](../assets/rdev7.png)
+![alt text](../assets/rdev7.png)
 
-**6) Build R**
+## 6. Build R
 
-Having configured R, we run `make` to build R. This take 5-10 minutes on the
-codespace.
+Run `make` to build R (5-10 minutes on codespace):
 
 ```bash
 make
 ```
 
-**7) Check R**
+## 7. Run Tests
 
-Check that the build of R passes R's standard checks:
+Check that the build passes R's standard tests:
 
 ```bash
 make check
 ```
 
-This takes a couple of minutes in the codespace. The check will stop with a
-error message if any of the tests fail. If this happens, see [SVN
-Help](./svn_help.md) for how to revert to a version that passes check.
+This takes a couple of minutes. If any tests fail, see [SVN Help](./svn_help.md) for how to revert to a working version.
 
-**8) Make R terminals use the built R**
+## 8. Configure R Terminal
 
-Run the `which_r` script to set which R to use for R terminals in VSCode. When
-prompted, enter the number corresponding to `r-devel`
+Run `which_r` to set which R version to use in VSCode's R terminals:
 
 ```bash
 which_r
 ```
 
-```bash
+You'll see this prompt:
+```
 Which version of R should be used in new R terminals?
   1. R 4.4.0 (release version built into this container)
   Additional R builds available:
@@ -118,16 +101,11 @@ Which version of R should be used in new R terminals?
 Enter the number corresponding to the selected version:
 ```
 
-This means that new R terminals will use the version of R you have just
-built![^1]
+Select the number for `r-devel`. New R terminals will now use your newly built version.[^1]
 
-[^1]: To switch back to the release version, run `which_r` and type `1`. The
-selected version is saved in the VSCode settings, so will be saved when you stop
-and restart the codespace.
+[^1]: To switch back to the release version, run `which_r` and select `1`. Your selection is saved in VSCode settings and persists across codespace restarts.
 
-**9) Make contributions**
+## 9. Next Steps
 
-- After having built the current development version of R, we can now make
-  changes to the source code and contribute to the project.
-- Follow the [R Contribution Workflow](./contribution_workflow.md) tutorial to
-  learn how to do this.
+Now that you've built the development version of R, you can start contributing to the project.
+Follow the [R Contribution Workflow](./contribution_workflow.md) tutorial to learn how.

--- a/docs/tutorials/building_r.md
+++ b/docs/tutorials/building_r.md
@@ -40,11 +40,15 @@ $TOP_SRCDIR/tools/rsync-recommended
 To keep the source directory clean, we'll use a separate build directory:
 
 1. Create the build directory:
+
+
    ```bash
    mkdir -p $BUILDDIR
    ```
 
+
 2. Change to the build directory:
+
    ```bash
    cd $BUILDDIR
    ```
@@ -92,7 +96,9 @@ Run `which_r` to set which R version to use in VSCode's R terminals:
 which_r
 ```
 
+
 You'll see this prompt:
+
 ```
 Which version of R should be used in new R terminals?
   1. R 4.4.0 (release version built into this container)

--- a/docs/tutorials/building_r.md
+++ b/docs/tutorials/building_r.md
@@ -9,29 +9,33 @@ The following environment variables define paths for building R:
 
 These variables are set in the codespace image and available at startup.
 
-![alt text](../assets/rdev6.png)
-
 ## 2. SVN Checkout
 
 Get a local copy of R source code from the repository:
 
-```bash
-svn checkout https://svn.r-project.org/R/trunk/ $TOP_SRCDIR
+```console
+$ svn checkout https://svn.r-project.org/R/trunk/ $TOP_SRCDIR
+A    trunk/COPYING
+A    trunk/INSTALL
+...
+Checked out revision 86543.
 ```
-
-After checkout, you'll see:
-
-![alt text](../assets/rdev8.png)
 
 ## 3. Download Packages
 
 Get recommended packages:
 
-```bash
-$TOP_SRCDIR/tools/rsync-recommended
+```console
+$ $TOP_SRCDIR/tools/rsync-recommended
+downloading recommended packages
+trying URL 'https://cran.r-project.org/src/contrib/Recommended/MASS_7.3-60.tar.gz'
+...
+** building package indices
+** testing if installed package can be loaded from temporary location
+** testing if installed package can be loaded from final location
+** testing if installed package keeps a record of temporary installation path
+* DONE
 ```
-
-![alt text](../assets/rdev9.png)
 
 ## 4. Set Up Build Directory
 
@@ -53,18 +57,19 @@ Keep source directory clean by using a separate build directory:
 
 Run configure (~1 minute):
 
-```bash
-$TOP_SRCDIR/configure --with-valgrind-instrumentation=1
+```console
+$ $TOP_SRCDIR/configure --with-valgrind-instrumentation=1
+checking build system type... x86_64-pc-linux-gnu
+checking host system type... x86_64-pc-linux-gnu
+...
+config.status: creating po/Makefile
+config.status: creating src/include/config.h
 ```
 
 !!! Note
     The `--with-valgrind-instrumentation` option enables effective use of
     valgrind. See the [docs](https://cran.r-project.org/doc/manuals/R-exts.html#Using-valgrind)
     for details.
-
-After configuration:
-
-![alt text](../assets/rdev7.png)
 
 ## 6. Build R
 
@@ -88,13 +93,8 @@ If tests fail, see [SVN Help](./svn_help.md).
 
 Set R version for VSCode:
 
-```bash
-which_r
-```
-
-You'll see:
-
-```text
+```console
+$ which_r
 Which version of R should be used in new R terminals?
 1. R 4.4.0 (release version built into this container)
 Additional R builds available:

--- a/docs/tutorials/contribution_workflow.md
+++ b/docs/tutorials/contribution_workflow.md
@@ -1,4 +1,6 @@
-#### 1. Example Contribution Workflow using the R Dev Container
+# Example Contribution Workflow using the R Dev Container
+
+## 1. Starting R
 
 - To start working in R we will click on `R:(not attach)` which is in the bottom
   right of the VSCode window. This will open an R terminal for us.
@@ -18,7 +20,7 @@
     [1] TRUE
 ```
 
-#### 2. Editing Source Code
+## 2. Editing Source Code
 
 - Edit the source code of `utils::askYesNo()` to change the default options. The
   source code can be found in `$TOP_SRCDIR/src/library/utils/R/askYesNo.R`.
@@ -28,21 +30,23 @@
 code $TOP_SRCDIR/src/library/utils/R/askYesNo.R
 ```
 
-**> Before edit:** ![alt text](../assets/rdev20.png)
+### Before and After Edit
+
+#### Before edit:
+![alt text](../assets/rdev20.png)
 
 ```R title="askYesNo.R" linenums="20"
     prompts = getOption("askYesNo", gettext(c("Yes", "No", "Cancel"))),
 ```
 
-**> With edit (for example - change to whatever you like!):**
-
+#### After edit (for example - change to whatever you like!):
 ![alt text](../assets/rdev21.png)
 
 ```R title="askYesNo.R" linenums="20"
     prompts = getOption("askYesNo", gettext(c("Oh yeah!", "Don't think so", "Cancel"))),
 ```
 
-#### 3. Rebuild R
+## 3. Rebuilding R
 
 - We can re-build R with our changes. Since we have only modified the utils
   package, rebuilding R will only re-build the utils package.
@@ -69,13 +73,12 @@ make
 
 - To use the re-built R, simply open a new R terminal.
 
-#### 4. Cross check and Re-running Code
+## 4. Cross-checking Changes
 
-- Check the edit has worked as expected by re-running the example code: ![alt
-text](../assets/rdev23.png)
+- Check the edit has worked as expected by re-running the example code: 
+![alt text](../assets/rdev23.png)
 
 ```R
     > askYesNo("Is this a good example?")
     Is this a good example? (Oh yeah!/don't think so/cancel) Oh yeah!
     [1] TRUE
-```

--- a/docs/tutorials/contribution_workflow.md
+++ b/docs/tutorials/contribution_workflow.md
@@ -32,14 +32,18 @@ code $TOP_SRCDIR/src/library/utils/R/askYesNo.R
 
 ### Before and After Edit
 
-#### Before edit:
+#### Before edit
+
+
 ![alt text](../assets/rdev20.png)
 
 ```R title="askYesNo.R" linenums="20"
     prompts = getOption("askYesNo", gettext(c("Yes", "No", "Cancel"))),
 ```
 
-#### After edit (for example - change to whatever you like!):
+
+#### After edit (for example - change to whatever you like!)
+
 ![alt text](../assets/rdev21.png)
 
 ```R title="askYesNo.R" linenums="20"
@@ -75,7 +79,7 @@ make
 
 ## 4. Cross-checking Changes
 
-- Check the edit has worked as expected by re-running the example code: 
+- Check the edit has worked as expected by re-running the example code:
 ![alt text](../assets/rdev23.png)
 
 ```R

--- a/docs/tutorials/contribution_workflow.md
+++ b/docs/tutorials/contribution_workflow.md
@@ -2,29 +2,27 @@
 
 ## 1. Starting R
 
-- To start working in R we will click on `R:(not attach)` which is in the bottom
-  right of the VSCode window. This will open an R terminal for us.
+- To start working in R, click on `R:(not attach)` in the bottom right of
+  VSCode. This will open an R terminal.
 
-    ![alt text](../assets/rdev11.png)
+![alt text](../assets/rdev11.png)
 
-    ![alt text](../assets/rdev12.png)
+![alt text](../assets/rdev12.png)
 
-- We can now run R commands. We will use the `utils::askYesNo()` function as an
-  example
-
-    ![alt text](../assets/rdev19.png)
+- We can now run R commands. We will use the `utils::askYesNo()` function as
+  an example:
 
 ```R
-    > askYesNo("Is this a good example?")
-    Is this a good example? (Yes/no/cancel) Yes
-    [1] TRUE
+> askYesNo("Is this a good example?")
+Is this a good example? (Yes/no/cancel) Yes
+[1] TRUE
 ```
 
 ## 2. Editing Source Code
 
-- Edit the source code of `utils::askYesNo()` to change the default options. The
-  source code can be found in `$TOP_SRCDIR/src/library/utils/R/askYesNo.R`.
-- You can redirect to that file using
+- Edit the source code of `utils::askYesNo()` to change the default options.
+  The source code is in `$TOP_SRCDIR/src/library/utils/R/askYesNo.R`.
+- You can redirect to that file using:
 
 ```bash
 code $TOP_SRCDIR/src/library/utils/R/askYesNo.R
@@ -34,20 +32,14 @@ code $TOP_SRCDIR/src/library/utils/R/askYesNo.R
 
 #### Before edit
 
-
-![alt text](../assets/rdev20.png)
-
 ```R title="askYesNo.R" linenums="20"
-    prompts = getOption("askYesNo", gettext(c("Yes", "No", "Cancel"))),
+prompts = getOption("askYesNo", gettext(c("Yes", "No", "Cancel"))),
 ```
 
-
-#### After edit (for example - change to whatever you like!)
-
-![alt text](../assets/rdev21.png)
+#### After edit
 
 ```R title="askYesNo.R" linenums="20"
-    prompts = getOption("askYesNo", gettext(c("Oh yeah!", "Don't think so", "Cancel"))),
+prompts = getOption("askYesNo", gettext(c("Oh yeah!", "Don't think so", "Cancel"))),
 ```
 
 ## 3. Rebuilding R
@@ -69,10 +61,8 @@ cd $BUILDDIR
 make
 ```
 
-![alt text](../assets/rdev22.png)
-
-- Optionally run `make check` to run R's test suite with your local changes. You
-  may skip this step while you are iterating on a bug fix or other development,
+- Optionally run `make check` to run R's test suite with your local changes.
+  You may skip this step while iterating on a bug fix or other development,
   until you are ready to [create a patch](./patch_update.md).
 
 - To use the re-built R, simply open a new R terminal.
@@ -80,9 +70,8 @@ make
 ## 4. Cross-checking Changes
 
 - Check the edit has worked as expected by re-running the example code:
-![alt text](../assets/rdev23.png)
 
 ```R
-    > askYesNo("Is this a good example?")
-    Is this a good example? (Oh yeah!/don't think so/cancel) Oh yeah!
-    [1] TRUE
+> askYesNo("Is this a good example?")
+Is this a good example? (Oh yeah!/don't think so/cancel) Oh yeah!
+[1] TRUE

--- a/docs/tutorials/running_r.md
+++ b/docs/tutorials/running_r.md
@@ -1,7 +1,6 @@
-
-1) Create a file in VS Code ending with a .R extension. You can create new files
-by clicking on the new file icon in VS Code Explorer, or use the `code` command
-in the terminal to create and open an R file
+1. Create a file in VS Code ending with a .R extension. You can create new files
+   by clicking on the new file icon in VS Code Explorer, or use the `code` command
+   in the terminal to create and open an R file
 
 ```bash
 code R/test.R
@@ -9,12 +8,12 @@ code R/test.R
 
 ![alt text](../assets/rdev4.png)
 
-2) You should see `R:(not attached)` in the Status Bar at the bottom of the
-VSCode window.
+2. You should see `R:(not attached)` in the Status Bar at the bottom of the
+   VSCode window.
 
 ![alt text](../assets/rdev11.png)
 
-3) Click on the `R:(not attached)` link to launch an R terminal. You can then
-send code from the `.R` file to the R terminal by pressing `cmd/ctrl + enter`.
+3. Click on the `R:(not attached)` link to launch an R terminal. You can then
+   send code from the `.R` file to the R terminal by pressing `cmd/ctrl + enter`.
 
 ![alt text](../assets/rdev12.png) ![alt text](../assets/rdev5.png)

--- a/docs/tutorials/running_r.md
+++ b/docs/tutorials/running_r.md
@@ -1,19 +1,24 @@
 1. Create a file in VS Code ending with a .R extension. You can create new files
    by clicking on the new file icon in VS Code Explorer, or use the `code` command
-   in the terminal to create and open an R file
+   in the terminal to create and open an R file:
 
-```bash
-code R/test.R
+```console
+$ code R/test.R
 ```
 
-![alt text](../assets/rdev4.png)
-
 2. You should see `R:(not attached)` in the Status Bar at the bottom of the
-   VSCode window.
+   VSCode window. Click on the `R:(not attached)` link to launch an R terminal.
 
-![alt text](../assets/rdev11.png)
+3. You can then send code from the `.R` file to the R terminal. For example:
 
-3. Click on the `R:(not attached)` link to launch an R terminal. You can then
-   send code from the `.R` file to the R terminal by pressing `cmd/ctrl + enter`.
+```R
+# In test.R
+print("Hello R Development!")
+```
 
-![alt text](../assets/rdev12.png) ![alt text](../assets/rdev5.png)
+```Rconsole
+> print("Hello R Development!")
+[1] "Hello R Development!"
+```
+
+You can send code from the editor to the R terminal by pressing `cmd/ctrl + enter`.

--- a/docs/tutorials/running_r.md
+++ b/docs/tutorials/running_r.md
@@ -3,7 +3,7 @@
    in the terminal to create and open an R file:
 
 ```console
-$ code R/test.R
+de R/test.R
 ```
 
 2. You should see `R:(not attached)` in the Status Bar at the bottom of the

--- a/docs/tutorials/update_source.md
+++ b/docs/tutorials/update_source.md
@@ -1,56 +1,64 @@
+# Updating R Source Code
+
 The R Core Team commit changes to the development version of R sometimes
 multiple times a day. It's a good idea to update your local copy of the source
 code from time to time, especially before creating a patch. To do so, follow
 these steps:
 
-#### 1) Close R terminal
+## 1. Close R Terminal
 
 If you have an R terminal open, quit R or close the terminal.
 
-#### 2) Go to the source directory
+## 2. Go to the Source Directory
 
-In a bash terminal, change to the source directory
+In a bash terminal, change to the source directory:
 
 ```bash
 cd $TOP_SRCDIR
 ```
 
-#### 3) Review local changes
+## 3. Review Local Changes
 
-Use the Subversion diff command to review changes you have made to source code
+Use the Subversion diff command to review changes you have made to source code:
 
 ```bash
 svn diff
 ```
 
-#### 4) Revert changes (optional)
+## 4. Revert Changes (Optional)
 
 If you no longer want to keep your local changes, you can revert them.
 
-Revert the changes made in specific file
+### Revert Specific Files
+
+To revert changes made in a specific file:
 
 ```bash
 svn revert src/library/utils/R/askYesNo.R
 ```
 
-Revert changes in a directory
+### Revert Directories
+
+To revert changes in a directory:
 
 ```bash
 svn revert src/lib/utils
 ```
 
-Revert all local changes
+### Revert All Changes
+
+To revert all local changes:
 
 ```bash
 svn revert -R .
 ```
 
-#### 5) Rebuild and check with any local changes
+## 5. Rebuild and Check Local Changes
 
 If you have no local changes remaining, skip to the next step.
 
 Otherwise, go to the build directory to build and check R with your local
-changes.
+changes:
 
 ```bash
 cd $BUILDDIR
@@ -60,25 +68,25 @@ make check
 
 If the check fails with an error, you have broken something with your local
 changes. Fix this before proceeding. Otherwise go back to the source directory
-to continue
+to continue:
 
 ```bash
 cd $TOP_SRCDIR
 ```
 
-#### 6) Update using svn
+## 6. Update Using SVN
 
 Use the Subversion command `update` to update your local copy with the latest
-changes by the R Core Team.
+changes by the R Core Team:
 
 ```bash
 svn update
 ```
 
-#### 7)  Rebuild and check with the updates
+## 7. Rebuild and Check Updates
 
 To rebuild R with the latest changes from the R Core Team and any local changes
-you have kept, go to the build directory to build and check R
+you have kept:
 
 ```bash
 cd $BUILDDIR

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,85 +1,109 @@
-site_name: R Devel Container Docs
-repo_name: r-devel/r-dev-env
+site_name: R Development Environment
+site_url: https://r-devel.github.io/r-dev-env/
 repo_url: https://github.com/r-devel/r-dev-env
-nav:
-    - 'Home': 'index.md'
-    - 'Container Setup':
-        - 'Overview': 'container_setup/index.md'
-        - 'Github Codespace':
-            - 'Starting Codespace': 'container_setup/github_codespace/creating_codespace.md'
-            - 'Stopping and Restarting' : 'container_setup/github_codespace/codespacestartstop.md'
-            - 'Collaborating with Live Share' : 'container_setup/github_codespace/live_share.md'
-        - 'Gitpod Workspace':
-             - 'Start Workspace': 'container_setup/gitpod_workspace/workspacestart.md'
-             - 'Stopping and Restarting' : 'container_setup/gitpod_workspace/workspacestop_and_restart.md'
-             - 'Collaborating with Live Share' : 'container_setup/gitpod_workspace/live_share.md'
-        - 'Local Setup' :
-               - 'Docker': 'container_setup/local_setup/localsetup.md'
-    - 'Tutorials':
-        - 'Running R' : 'tutorials/running_r.md'
-        - 'Building R': 'tutorials/building_r.md'
-        - 'R Contribution Workflow' : 'tutorials/contribution_workflow.md'
-        - 'Updating Source Code' : 'tutorials/update_source.md'
-        - 'Creating a Patch File' : 'tutorials/patch_update.md'
-        - 'Multiple R Versions' : 'tutorials/multi_r_compilation.md'
-        - 'SVN Help' : 'tutorials/svn_help.md'
-    - 'Contributor Guide' :
-        - 'contributor_guide/contributing_to_docs.md'
-        - 'contributor_guide/contributing_to_codebase.md'
-    - 'Resources' : 'resources.md'
-    - 'Troubleshooting Info' : 'troubleshoot.md'
+repo_name: r-devel/r-dev-env
+edit_uri: edit/main/docs/
+
 theme:
   name: material
   features:
-    - navigation.tabs
+    - navigation.instant
+    - navigation.tracking
     - navigation.sections
-    - toc.integrate
+    - navigation.expand
+    - navigation.indexes
     - navigation.top
-    - search.suggest
-    - search.highlight
-    - content.tabs.link
-    - content.code.annotation
+    - toc.follow
     - content.code.copy
-
-
+    - content.code.annotate
   palette:
-    - scheme: default
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
       primary: indigo
-      accent: blue
-    - scheme: slate
+      accent: indigo
       toggle:
         icon: material/brightness-4
         name: Switch to light mode
-      primary: indigo
-      accent: blue
 
 plugins:
-  - social
-
-extra:
-  social:
-    - icon: fontawesome/brands/github
-      link: https://github.com/r-devel/r-dev-env/
-    - icon: fontawesome/brands/slack
-      link: https://r-contributors.slack.com/
+  - search
+  - git-revision-date-localized:
+      enable_creation_date: true
+      type: timeago
 
 markdown_extensions:
-  - pymdownx.highlight:
-      anchor_linenums: true
-  - pymdownx.inlinehilite
-  - pymdownx.snippets
+  - abbr
   - admonition
-  - pymdownx.arithmatex:
-      generic: true
-  - footnotes
-  - pymdownx.details
-  - pymdownx.superfences
-  - pymdownx.mark
   - attr_list
+  - def_list
+  - footnotes
+  - md_in_html
   - toc:
       permalink: true
-      permalink_title: Anchor link to this section for reference
-      slugify: !!python/name:pymdownx.slugs.uslugify
+      toc_depth: 3
+  - pymdownx.arithmatex:
+      generic: true
+  - pymdownx.betterem:
+      smart_enable: all
+  - pymdownx.caret
+  - pymdownx.details
+  - pymdownx.emoji:
+      emoji_generator: material.extensions.emoji.to_svg
+      emoji_index: material.extensions.emoji.twemoji
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.keys
+  - pymdownx.magiclink:
+      repo_url_shorthand: true
+      user: r-devel
+      repo: r-dev-env
+  - pymdownx.mark
+  - pymdownx.smartsymbols
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.tilde
+
+nav:
+  - Home: index.md
+  - Container Setup:
+      - container_setup/index.md
+      - GitHub Codespace:
+          - container_setup/github_codespace/creating_codespace.md
+          - container_setup/github_codespace/codespacestartstop.md
+          - container_setup/github_codespace/live_share.md
+      - Gitpod Workspace:
+          - container_setup/gitpod_workspace/workspacestart.md
+          - container_setup/gitpod_workspace/workspacestop_and_restart.md
+          - container_setup/gitpod_workspace/live_share.md
+      - Local Setup:
+          - container_setup/local_setup/localsetup.md
+  - Tutorials:
+      - tutorials/building_r.md
+      - tutorials/running_r.md
+      - tutorials/contribution_workflow.md
+      - tutorials/update_source.md
+      - tutorials/patch_update.md
+      - tutorials/svn_help.md
+      - tutorials/multi_r_compilation.md
+  - Contributor Guide:
+      - contributor_guide/contributing_to_codebase.md
+      - contributor_guide/contributing_to_docs.md
+  - Resources: resources.md
+  - Troubleshooting: troubleshoot.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,3 +79,7 @@ markdown_extensions:
   - pymdownx.superfences
   - pymdownx.mark
   - attr_list
+  - toc:
+      permalink: true
+      permalink_title: Anchor link to this section for reference
+      slugify: !!python/name:pymdownx.slugs.uslugify


### PR DESCRIPTION
- Use ```console for terminal output
- Use ```Rconsole for R console output
- Replace text-only screenshots with fenced code blocks
- Improve accessibility and maintainability
- Follow recommendations from r-devel/r-dev-day#60

Changes made:
1. Updated building_r.md:
   - Added proper console output examples with ```console fencing
   - Removed redundant screenshots that just showed terminal output
   - Added example command outputs for better understanding

2. Updated running_r.md:
   - Added ```console fencing for terminal commands
   - Added ```R fencing for R code in editor
   - Added ```Rconsole fencing for R console output
   - Added clear example of R code and its output
   - Removed redundant screenshots

These changes make the documentation more accessible to screen readers and easier to maintain.