### PR TITLE
Fix #219: Configure VS Code tabSize=8 and indentSize=4

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,6 +7,9 @@
     "customizations": {
         "vscode": {
             "settings": {
+                "editor.tabSize": 8,  
+                "editor.indentSize": 4,  
+                "editor.detectIndentation": false,
                 "r.lsp.diagnostics": false,
                 "r.plot.useHttpgd": true,
                 "r.rpath.linux": "/usr/bin/R",


### PR DESCRIPTION

**Description:**

This pull request updates the VS Code settings in `.devcontainer/devcontainer.json` to ensure consistent indentation and tab display for R code:

- Sets `"editor.tabSize"` to 8, matching base R’s tab display width.
- Sets `"editor.indentSize"` to 4, so pressing Tab inserts 4 spaces (modern indentation).
- Sets `"editor.detectIndentation"` to false to enforce these settings and prevent VS Code from auto-detecting indentation.

This change ensures all contributors have a consistent editing experience in the dev container, as discussed in #219.
