### PR TITLE
Update workflows

### DIFF
--- a/.github/workflows/build-and-publish-image.yml
+++ b/.github/workflows/build-and-publish-image.yml
@@ -16,6 +16,9 @@ on:
       - 'reinstall-cmake.sh'
       - 'VERSION'
 
+permissions:
+  contents: read
+  packages: write
 
 env:
   REGISTRY: ghcr.io
@@ -27,9 +30,6 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/build-and-publish-image.yml
+++ b/.github/workflows/build-and-publish-image.yml
@@ -23,7 +23,9 @@ env:
 
 jobs:
   build-and-push-image:
-    if: ${{github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true}}
+    if:  |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/build-gitpod-image.yml
+++ b/.github/workflows/build-gitpod-image.yml
@@ -17,6 +17,9 @@ on:
       - 'reinstall-cmake.sh'
       - 'VERSION'
 
+permissions:
+  contents: read
+  packages: write
 
 env:
   REGISTRY: ghcr.io
@@ -28,9 +31,6 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/build-gitpod-image.yml
+++ b/.github/workflows/build-gitpod-image.yml
@@ -24,7 +24,9 @@ env:
 
 jobs:
   build-and-push-image:
-    if: ${{github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true}}
+    if:  |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/optimize-docs-images.yml
+++ b/.github/workflows/optimize-docs-images.yml
@@ -1,6 +1,7 @@
 name: Optimize Docs Images
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: ["main","devel"]
     types: [closed]
@@ -9,7 +10,9 @@ on:
 
 jobs:
   optimize-images:
-    if: ${{github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true}}
+    if:  |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/schedule-docker-build.yml
+++ b/.github/workflows/schedule-docker-build.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '0 0 1,15 * *'
 
+permissions:
+  contents: read
+  packages: write
 
 env:
   REGISTRY: ghcr.io
@@ -12,9 +15,6 @@ env:
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
     strategy:
       matrix:
         branch: [main, devel]


### PR DESCRIPTION
Make a couple of changes across GitHub actions, that I previously made only to the "Build MKDocs website" workflow:

* update `if:` so that the job runs on workflow dispatch or a merged PR to the main or devel branch (this allows us to run the action on demand)
* move permissions from local (within job) to global for the workflows that attempt to build and push - it seems this is now necessary for the actions to work