### PR TITLE
Update builds and deploy workflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN if [ "${REINSTALL_CMAKE_VERSION_FROM_SOURCE}" != "none" ]; then \
     fi \
     && rm -f /tmp/reinstall-cmake.sh
 
+# software-properties-common installed for apt-add-repository
 RUN sed -i.bak "/^#.*deb-src.*universe$/s/^# //g" /etc/apt/sources.list \
     && apt -y update \
     && apt install -y --no-install-recommends \
@@ -22,13 +23,6 @@ RUN sed -i.bak "/^#.*deb-src.*universe$/s/^# //g" /etc/apt/sources.list \
     && Rscript -e "install.packages('languageserver', repos='https://cran.rstudio.com')" \
     && Rscript -e "install.packages('httpgd', repos='https://cran.rstudio.com')" \
     && rm -rf /var/lib/apt/lists/*
-
-RUN apt install shellcheck
-RUN apt install -y ccache
-#RUN /usr/sbin/update-ccache-symlinks
-#RUN echo 'export PATH="/usr/lib/ccache:$PATH"' | tee -a /home/vscode/.bashrc
-
-
 
 ARG CONTAINER_VERSION
 ENV CONTAINER_VERSION ${CONTAINER_VERSION}

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,8 @@ RUN sed -i.bak "/^#.*deb-src.*universe$/s/^# //g" /etc/apt/sources.list \
     && wget -qO- https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc | sudo tee -a /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc \
     && apt -y build-dep r-base-dev \
     && apt -y install r-base-dev \
-    && Rscript -e "install.packages('languageserver', repos='https://cran.rstudio.com')" \
-    && Rscript -e "install.packages('httpgd', repos='https://cran.rstudio.com')" \
+    && Rscript -e "install.packages(c('languageserver', 'httpgd'), \
+    repos = c(runiverse='https://r-universe.dev', CRAN='https://cloud.r-project.org'))" \
     && rm -rf /var/lib/apt/lists/*
 
 ARG CONTAINER_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN sed -i.bak "/^#.*deb-src.*universe$/s/^# //g" /etc/apt/sources.list \
       software-properties-common \
       subversion \
     && add-apt-repository --enable-source --yes "ppa:marutter/rrutter4.0" \
-    && wget -qO- https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc | sudo tee -a /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc \
+    && wget -qO- https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc | tee -a /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc \
     && apt -y build-dep r-base-dev \
     && apt -y install r-base-dev \
     && Rscript -e "install.packages(c('languageserver', 'httpgd'), \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN sed -i.bak "/^#.*deb-src.*universe$/s/^# //g" /etc/apt/sources.list \
     && apt -y build-dep r-base-dev \
     && apt -y install r-base-dev \
     && Rscript -e "install.packages(c('languageserver', 'httpgd'), \
-    repos = c(runiverse='https://r-universe.dev', CRAN='https://cloud.r-project.org'))" \
+    repos = c(CRAN='https://cloud.r-project.org'))" \
     && rm -rf /var/lib/apt/lists/*
 
 ARG CONTAINER_VERSION


### PR DESCRIPTION
A couple of updates 

1. Don't install shellcheck and ccache - these aren't being used in our GitHub action workflows, or the Devcontainer configuration and aren't likely to be used by contributors as these tools aren't covered in the tutorials.
2. Don't use sudo in Docker RUN command - not needed as the command will be run as root