### PR TITLE
Use console and Rconsole fenced code blocks for input/output examples

### DIFF
--- a/.github/workflows/build-mkdocs-website.yml
+++ b/.github/workflows/build-mkdocs-website.yml
@@ -12,7 +12,7 @@ on:
 
 permissions:
   contents: write
-  
+
 jobs:
   build-and-deploy:
     if: |

--- a/docs/container_setup/local_setup/localsetup.md
+++ b/docs/container_setup/local_setup/localsetup.md
@@ -60,6 +60,7 @@ localsetup](../../assets/rdev24.png)
 the environment variables mentioned in the welcome message on the
 terminal. And there we go!!! We have setup our R Dev Container locally.
 
-   ```bash
-   echo $BUILDDIR
-   ```
+    ```console
+    $ echo $BUILDDIR
+    /workspaces/r-dev-env/bin/R
+    ```

--- a/docs/container_setup/local_setup/localsetup.md
+++ b/docs/container_setup/local_setup/localsetup.md
@@ -52,13 +52,14 @@ systemctl start docker
 in Dev Container.  Click on `Reopen in DevContainer` button.  ![start
 localsetup](../../assets/rdev13.png)
 
-7. After clicking on that button we will see our container is getting ready. It
+7. After clicking on that button we will see our container is getting
+ready. It
 will take some time. So till that time you can have coffee :) ![start
 localsetup](../../assets/rdev24.png)
 8. We can also test whether the dev container is working or not by just printing
-the environment variables mentioned in the welcome message on the terminal. And
-there we go!!! We have setup our R Dev Container locally.  ![start
-localsetup](../../assets/rdev25.png)
+the environment variables mentioned in the welcome message on the
+terminal. And there we go!!! We have setup our R Dev Container locally.
 
-9. The container will be closed when you close VSCode. To reopen the container,
-   open the `r-dev-env` directory in VSCode.
+   ```bash
+   echo $BUILDDIR
+   ```

--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -1,0 +1,37 @@
+/* customise CSS for bash code chunks and bash sessions ("console") */
+
+/* .gp = Generic Prompt (e.g., shell prompt like $ or >) */
+/* default: var(--md-code-hl-generic-color); */
+/* prompts treated as normal code in bash code chunks */
+.language-console.highlight code span.gp{
+  color: #7aa2cd;
+}
+
+/* .go = Generic output: output from a command */
+/* default: var(--md-code-hl-generic-color); */
+.language-console.highlight code span.go,
+.language-bash.highlight code span.go {
+  color: var(--md-code-hl-generic-color);
+}
+
+/* .nb = Built-in name like print, echo */
+/* default: var(--md-code-hl-constant-color); */
+.language-console.highlight code span.nb,
+.language-bash.highlight code span.nb {
+  color: var(--md-code-hl-constant-color);
+}
+
+/* .nv = Named variables like $BUILDDIR */
+/* default: var(--md-code-hl-variable-color); */
+/* use same as normal text: var(--md-code-fg-color); */
+.language-console.highlight code span.nv,
+.language-bash.highlight code span.nv {
+  color: var(--md-code-fg-color);
+}
+
+/* .c1 = Built-in name like print, echo */
+/* default: var(--md-code-hl-comment-color); */
+.language-console.highlight code span.c1,
+.language-bash.highlight code span.c1 {
+  color: var(--md-code-hl-comment-color);
+}

--- a/docs/tutorials/running_r.md
+++ b/docs/tutorials/running_r.md
@@ -18,3 +18,7 @@ VSCode window.
 send code from the `.R` file to the R terminal by pressing `cmd/ctrl + enter`.
 
 ![alt text](../assets/rdev12.png) ![alt text](../assets/rdev5.png)
+
+```Rconsole
+hist(rnorm(1000))
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,9 @@ theme:
       primary: indigo
       accent: blue
 
+extra_css:
+  - css/custom.css
+
 plugins:
   - social
   - search
@@ -70,6 +73,8 @@ extra:
 
 markdown_extensions:
   - pymdownx.highlight:
+      use_pygments: true
+      pygments_lang_class: true
       anchor_linenums: true
   - pymdownx.inlinehilite
   - pymdownx.snippets


### PR DESCRIPTION
**Description**

- Removed the third Docker-related image from `container_setup/local_setup` and replaced it with a fenced code block showing the relevant terminal command and output.
- In `tutorials/running_r`, replaced the last image with the corresponding R code example using an `Rconsole` fenced code block.

These changes improve accessibility and maintainability by using code fencing for input/output examples instead of screenshots.

(closes #210)
