### PR TITLE
use different url when deploying from devel vs main

### DIFF
--- a/.github/workflows/build-mkdocs-website.yml
+++ b/.github/workflows/build-mkdocs-website.yml
@@ -31,6 +31,21 @@ jobs:
       - name: Install dependencies
         run: pip install mkdocs mkdocs-material[imaging]
 
+      - name: Determine deployment path
+        id: path
+        run: |
+          if [[ "${{ github.ref_name }}" == "main" ]]; then
+            echo "url=https://contributor.r-project.org/r-dev-env" >> "$GITHUB_OUTPUT"
+          else
+            echo "url=https://contributor.r-project.org/r-dev-env/devel" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Modify site_url in mkdocs.yml
+        run: |
+          echo "Setting site_url to ${{ steps.path.outputs.url }}"
+          sed -i "s|^site_url:.*|site_url: '${{ steps.path.outputs.url }}'|" mkdocs.yml
+
+
       - name: Build MkDocs
         run: mkdocs build
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,5 @@
 site_name: R Devel Container Docs
+site_url: ''
 repo_name: r-devel/r-dev-env
 repo_url: https://github.com/r-devel/r-dev-env
 nav:


### PR DESCRIPTION
Attempt to set base URL for docs according to whether they are built from the main or devel branch.

Expected behaviour:

* PR to main (affecting docs) -> https://contributor.r-project.org/r-dev-env
* PR to devel -> https://contributor.r-project.org/r-dev-env/devel
* manual trigger -> url set according to whether it is run from main or devel (can select before running)