### PR TITLE
 feat: add ImageMagick and Magick++ support to Dockerfile for graphical testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN sed -i.bak "/^#.*deb-src.*universe$/s/^# //g" /etc/apt/sources.list \
     && apt install -y --no-install-recommends \
       software-properties-common \
       subversion \
+      libmagick++-dev \
     && add-apt-repository --enable-source --yes "ppa:marutter/rrutter4.0" \
     && wget -qO- https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc | tee -a /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc \
     && apt -y build-dep r-base-dev \


### PR DESCRIPTION
This PR updates the Dockerfile to include development headers  for ImageMagick  (libmagick++-dev).
Addresses [issue #230](https://github.com/r-devel/r-dev-env/issues/230)