### PR TITLE
Fix: Ensure VS Code uses r-devel help docs when switched with which_r

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,8 +12,6 @@
                 "editor.detectIndentation": false,
                 "r.lsp.diagnostics": false,
                 "r.plot.useHttpgd": true,
-                "r.rpath.linux": "/usr/bin/R",
-                "r.rterm.linux": "/usr/bin/R",
                 "terminal.integrated.sendKeybindingsToShell": true,
                 "svn.multipleFolders.enabled": true,
                 "workbench.editorAssociations": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,14 +19,16 @@
                 "workbench.editorAssociations": {
                     "*.md": "vscode.markdown.preview.editor"
                 },
-                "workbench.welcomePage.walkthroughs.openOnInstall": false
+                "workbench.welcomePage.walkthroughs.openOnInstall": false,
+                "r.libPaths": ["/usr/local/lib/R/site-library"]
             },
             "extensions": [
                 "REditorSupport.r",
                 "mads-hartmann.bash-ide-vscode",
                 "johnstoncode.svn-scm",
                 "ms-vscode.cpptools",
-                "MS-vsliveshare.vsliveshare"
+                "MS-vsliveshare.vsliveshare",
+                "natqe.reload"
             ]
         }
     },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,6 +12,8 @@
                 "editor.detectIndentation": false,
                 "r.lsp.diagnostics": false,
                 "r.plot.useHttpgd": true,
+                "r.rpath.linux": "/usr/bin/R",
+                "r.rterm.linux": "/usr/bin/R",
                 "terminal.integrated.sendKeybindingsToShell": true,
                 "svn.multipleFolders.enabled": true,
                 "workbench.editorAssociations": {

--- a/docs/tutorials/contribution_workflow.md
+++ b/docs/tutorials/contribution_workflow.md
@@ -67,7 +67,9 @@ make
   may skip this step while you are iterating on a bug fix or other development,
   until you are ready to [create a patch](./patch_update.md).
 
-- To use the re-built R, simply open a new R terminal.
+- To use the re-built R, simply open a new R terminal. If you have made changes
+  to the help files, click "Reload" in the VS Code status bar (bottom right) to
+  reload your VS Code window.
 
 #### 4. Cross check and Re-running Code
 

--- a/scripts/which_r.sh
+++ b/scripts/which_r.sh
@@ -60,8 +60,9 @@ which_r() {
   fi
 
   # Update settings.json with the chosen R path
-  updated_settings_data=$(cat "$settings_file_path" | jq --arg subdir "$selected_version" '."r.rterm.linux"=$subdir')
+  updated_settings_data=$(cat "$settings_file_path" | jq --arg subdir "$selected_version" '."r.rterm.linux"=$subdir | ."r.rpath.linux"=$subdir')
   echo "$updated_settings_data" > "$settings_file_path"
 
   echo "R terminal will now use version: $selected_version"
+  echo "To update the HTML help, click \"Reload\" in the VS Code status bar (bottom right) to reload your VS Code window."
 }


### PR DESCRIPTION
Enables dynamic switching between release and r-devel help files via which_r

Resolves issue #228 by showing correct HTML help for chosen R version
