### PR TITLE
Test/lldb

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,7 @@
 {
     "name": "R-Dev-Env",
     "image": "ghcr.io/r-devel/r-dev-env:devel",
+    "runArgs": ["--cap-add=SYS_PTRACE"],
     "hostRequirements": {
         "cpus": 4
     },
@@ -13,7 +14,7 @@
                 "r.lsp.diagnostics": false,
                 "r.plot.useHttpgd": true,
                 "r.rpath.linux": "/usr/bin/R",
-                "r.rterm.linux": "/usr/bin/R",
+                "r.rterm.linux": "/workspaces/r-dev-env/scripts/launch_r.sh",
                 "terminal.integrated.sendKeybindingsToShell": true,
                 "svn.multipleFolders.enabled": true,
                 "workbench.editorAssociations": {
@@ -28,7 +29,8 @@
                 "johnstoncode.svn-scm",
                 "ms-vscode.cpptools",
                 "MS-vsliveshare.vsliveshare",
-                "natqe.reload"
+                "natqe.reload",
+                "vadimcn.vscode-lldb"
             ]
         }
     },

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@ R-4.1.3/
 R-4.1.3.tar.gz
 R-devel/
 R-devel.tar.gz
+/build
+/svn
 /venv
 .cache/
 .Rproj.user
+*.Rproj
+**.so

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,12 @@
+{
+"version": "0.2.0",
+"configurations": [
+    {
+      "name": "(lldb) Attach to R",
+      "type": "lldb",
+      "request": "attach",
+      "pid": "${command:pickMyProcess}",
+      "stopOnEntry": false
+    }
+  ]
+}

--- a/scripts/allow_ptrace.c
+++ b/scripts/allow_ptrace.c
@@ -1,0 +1,7 @@
+#include <sys/prctl.h>
+#include <stdio.h>
+
+__attribute__((constructor)) void allow_ptrace() {
+    prctl(PR_SET_PTRACER, PR_SET_PTRACER_ANY);
+    fprintf(stderr, "allow_ptrace: called\n");
+}

--- a/scripts/launch_r.sh
+++ b/scripts/launch_r.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+export LD_PRELOAD=/workspaces/r-dev-env/scripts/allow_ptrace.so
+# which_r.sh needs updating to switch R version here vs in vscode settings
+# exec /workspaces/r-dev-env/build/r-devel/bin/R "$@"
+exec /usr/bin/R "$@"

--- a/scripts/localscript.sh
+++ b/scripts/localscript.sh
@@ -25,7 +25,7 @@ cat $WORK_DIR/scripts/welcome_msg.sh >> ~/.bashrc
 #bash ~/.bashrc
 
 # Remove git directory if it exists
-rm -rf .git
+# rm -rf .git
 
 # copying vscode extension settings from devcontainer json to vscode settings json using jq
 if [ -f "$DEVCONTAINER_JSON" ]; then


### PR DESCRIPTION
Opening this PR just to document the changes on this test branch, which demo a prototype LLDB setup.

You can try it out by building and running locally as described in the docs for [local setup](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), but switching to the test/lldb branch before launching vscode.

Then:

1. Compile `allow_ptrace.c` 
     ```
    gcc -shared -fPIC -o allow_ptrace.so allow_ptrace.c
    ```
2. Make the launch_r script executable 
    ```
    chmod +x /workspaces/r-dev-env/scripts/launch_r.sh
    ```
    At this stage you should be able to open an R terminal, which will use the pre-built version of R. Running `Sys.getenv("LD_PRELOAD")` should show `"/workspaces/r-dev-env/scripts/allow_ptrace.so"). Quit R.
3. Build R from source as usual (optionally setting `CFLAGS="-g -O0"` before the configure step).
4. Manually switch from the inbuilt version of R to the one you just built by editing the `launch.sh` script:
    ```
    # exec /workspaces/r-dev-env/build/r-devel/bin/R "$@"
    exec /usr/bin/R "$@"
    ```
    i.e. uncomment the one you want, comment the one you don't want
 5. Open a new R terminal. It should use the new version of R and show the same value for `Sys.getenv("LD_PRELOAD")` . 
 6. Start debugging with LLDB:
     * Run `Sys.getpid()` to get the process ID of R.
     * From the Run and Debug panel run "(lldb) Attach to R", input the pid to attach to the R process. 
     * Set a breakpoint on a C file in the local copy of the sources, e.g. $TOP_SRCDIR/src/nmath/rgamma.c
     * Run code using that function e.g. `rgamma(5,1)` and the debugger will start.
     
  Tested on Ubuntu 24.04 with fresh checkout from devel branch:
  
<img width="2013" height="1078" alt="lldb_on_r-devel" src="https://github.com/user-attachments/assets/9b8a1acc-0158-4312-8770-ad0f4cd27f95" />
<img width="2013" height="1078" alt="stepping_over_rgamma" src="https://github.com/user-attachments/assets/a5ed831c-5ea1-49b8-93d1-dec2b878ec0c" />

Note that debugger will not work for the pre-built version of R, as it was installed from a binary and we don't have access to the source files!

<img width="2013" height="1078" alt="lldb_on_prebuilt_r" src="https://github.com/user-attachments/assets/e38bee08-d078-489b-a470-ebd59fb62dd4" />

To get this working nicely we would want to do steps 1 and 2 as part of the devcontainer setup. Step 4 should be done by the which_r script - _not_ by simply editing comments, but dynamically switching the path to the R executable, in a similar way to how we currently switch the path in the vscode settings: https://github.com/r-devel/r-dev-env/blob/46b8b6c408a1a62abd8918edd53ec94a51f8a419/scripts/which_r.sh#L63-L64

After running the debugger we get a new button in the status bar labelled "(lldb) Attach to R (r-dev-env)" that you can use to select and start the debug configuration. This is okay, but it hides the "R: (not attached)" button. So either people need to hide some more things in the Status bar, or open R via the command palette. We would probably need to say something about this in the docs.