### PR TITLE
updated welcome_msg to remove init flag tracking to open index

### DIFF
--- a/scripts/welcome_msg.sh
+++ b/scripts/welcome_msg.sh
@@ -29,7 +29,7 @@ Have fun \U0001F601
 "
 
 # open INDEX.md if INIT file exists
-if [ -f "INIT" ]; then
+if [ ! -d "svn" ] && [ ! -d "build" ]; then
     sleep 2
     code INDEX.md
     rm INIT


### PR DESCRIPTION
Closes #263

Replace the use of the tracked `INIT` file with a more reliable method to detect a fresh container. Now, the help index is opened only if neither the `svn` (source) nor `build` (compiled R) directories exist, indicating the user has not yet started the R development workflow 