### PR TITLE
Add gdiff workflow support and install httpgd from GitHub with remotes

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -9,6 +9,35 @@
 # .libPaths() already includes site library for default R version.
 .libPaths(c(.libPaths(), .Library.site))
 
+
+# The remotes package is installed to install httpgd from GitHub
+# The gdiff package is installed to support visual difference testing
+
+# Configure r-universe for binary package installations dynamically
+linux_binary_repo <- function(universe){
+  runiverse <- sprintf('r-universe.dev/bin/linux/%s-%s/%s/',
+                       system2('lsb_release', '-sc', stdout = TRUE),
+                       R.version$arch,
+                       substr(getRversion(), 1, 3))
+  sprintf('https://%s.%s', universe, runiverse)
+}
+
+# Set repos for CRAN and nx10 (httpgd) to use r-universe linux binaries
+options(repos = c(
+  cran = linux_binary_repo("cran"),
+  nx10 = linux_binary_repo("nx10")
+))
+
+# VSCode httpgd graphics device integration (optional)
+if (interactive() && Sys.getenv("TERM_PROGRAM") == "vscode") {
+  if (requireNamespace("httpgd", quietly=TRUE)) {
+    options(vsc.plot = FALSE)
+    options(device = function(...) {
+      httpgd::hgd(silent = TRUE)
+      .vsc.browser(httpgd::hgd_url(history = FALSE), viewer = "Beside")
+    })
+  }
+}
 # For PNG graphics uncomment following lines
 # options(vsc.use_httpgd = FALSE,
 #         vsc.dev.args = list(width = 800, height = 600))

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,15 @@ RUN sed -i.bak "/^#.*deb-src.*universe$/s/^# //g" /etc/apt/sources.list \
       software-properties-common \
       subversion \
       libmagick++-dev \
+      libpoppler-cpp-dev \   
+      libfontconfig1-dev \
+      libfreetype6-dev \
+      libpng-dev \
+      libjpeg-dev \
+      libtiff-dev \
+      libharfbuzz-dev \
+      libfribidi-dev \
+      libcairo2-dev \ 
     && add-apt-repository --enable-source --yes "ppa:marutter/rrutter4.0" \
     && wget -qO- https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc | tee -a /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc \
     && apt-get update \
@@ -19,13 +28,15 @@ RUN sed -i.bak "/^#.*deb-src.*universe$/s/^# //g" /etc/apt/sources.list \
 # Install R packages, with dynamic r-universe URL
 RUN Rscript -e "runiverse <- sprintf('r-universe.dev/bin/linux/%s-%s/%s/', \
                                  system2('lsb_release', '-sc', stdout = TRUE), \
-                                 R.version\$arch, \
+                                 R.version$arch, \
                                  substr(getRversion(), 1, 3)); \
-                print('Installing packages...'); \
-                install.packages(c('languageserver', 'httpgd'), \
+                print('Installing packages from r-universe...'); \
+                install.packages(c('languageserver', 'gdiff', 'remotes'), \
                  repos = c(runiverse = paste0('https://cran.', runiverse), \
                            nx10 = paste0('https://nx10.', runiverse))); \
-                print('Packages installed.')"
+                print('Installing httpgd from GitHub...'); \
+                remotes::install_github('nx10/httpgd'); \
+                print('All packages installed.')"
 
 # Define env var used in GitHub Actions that build and deploy container
 ARG CONTAINER_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN sed -i.bak "/^#.*deb-src.*universe$/s/^# //g" /etc/apt/sources.list \
       software-properties-common \
       subversion \
       libmagick++-dev \
-      libpoppler-cpp-dev \   
+      libpoppler-cpp-dev \
       libfontconfig1-dev \
       libfreetype6-dev \
       libpng-dev \
@@ -16,7 +16,7 @@ RUN sed -i.bak "/^#.*deb-src.*universe$/s/^# //g" /etc/apt/sources.list \
       libtiff-dev \
       libharfbuzz-dev \
       libfribidi-dev \
-      libcairo2-dev \ 
+      libcairo2-dev \
     && add-apt-repository --enable-source --yes "ppa:marutter/rrutter4.0" \
     && wget -qO- https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc | tee -a /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc \
     && apt-get update \


### PR DESCRIPTION
This PR addresses issues #271 and #227 by enhancing the R development container setup to support the regression testing workflow using gdiff and by resolving the httpgd installation challenge using remotes.

- Installed gdiff and its system dependencies (libmagick++-dev, libpoppler-cpp-dev) to enable graphical difference testing as outlined in #271.

- Configured dynamic r-universe Linux binary repositories in both Dockerfile and .Rprofile to speed up package installations and ensure compatibility with the container environment.

- Installed httpgd from GitHub via remotes because it is not available on CRAN, resolving the issue described in #227.

- Added all required system libraries for httpgd to function correctly, including font rendering and graphics support dependencies.

- Updated .Rprofile to include repository settings and optional VSCode integration for httpgd as the default graphics device to improve user experience.
