### PR TITLE
Add gdiff workflow support and install httpgd from GitHub with remotes

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -9,6 +9,23 @@
 # .libPaths() already includes site library for default R version.
 .libPaths(c(.libPaths(), .Library.site))
 
+# The remotes package is installed to install httpgd from GitHub
+# The gdiff package is installed to support visual difference testing
+
+# Configure r-universe for binary package installations dynamically
+linux_binary_repo <- function(universe){
+  runiverse <- sprintf('r-universe.dev/bin/linux/%s-%s/%s/',
+                       system2('lsb_release', '-sc', stdout = TRUE),
+                       R.version$arch,
+                       substr(getRversion(), 1, 3))
+  sprintf('https://%s.%s', universe, runiverse)
+}
+
+# Set repos for CRAN and nx10 (httpgd) to use r-universe linux binaries
+options(repos = c(
+  cran = linux_binary_repo("cran")
+))
+
 # For PNG graphics uncomment following lines
 # options(vsc.use_httpgd = FALSE,
 #         vsc.dev.args = list(width = 800, height = 600))

--- a/.Rprofile
+++ b/.Rprofile
@@ -21,7 +21,7 @@ linux_binary_repo <- function(universe){
   sprintf('https://%s.%s', universe, runiverse)
 }
 
-# Set repos for CRAN and nx10 (httpgd) to use r-universe linux binaries
+# Set repos for CRAN to use r-universe linux binaries
 options(repos = c(
   cran = linux_binary_repo("cran")
 ))

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN sed -i.bak "/^#.*deb-src.*universe$/s/^# //g" /etc/apt/sources.list \
       software-properties-common \
       subversion \
       libmagick++-dev \
+      libpoppler-cpp-dev \
     && add-apt-repository --enable-source --yes "ppa:marutter/rrutter4.0" \
     && wget -qO- https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc | tee -a /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc \
     && apt-get update \
@@ -22,9 +23,10 @@ RUN Rscript -e "runiverse <- sprintf('r-universe.dev/bin/linux/%s-%s/%s/', \
                                  R.version\$arch, \
                                  substr(getRversion(), 1, 3)); \
                 print('Installing packages...'); \
-                install.packages(c('languageserver', 'httpgd'), \
-                 repos = c(runiverse = paste0('https://cran.', runiverse), \
-                           nx10 = paste0('https://nx10.', runiverse))); \
+                install.packages(c('languageserver', 'gdiff', 'remotes'), \
+                 repos = c(runiverse = paste0('https://cran.', runiverse))); \
+                print('Installing httpgd from GitHub...'); \
+                remotes::install_github('nx10/httpgd'); \
                 print('Packages installed.')"
 
 # Define env var used in GitHub Actions that build and deploy container


### PR DESCRIPTION
This PR addresses issues #271 and #227 by enhancing the R development container setup to support the regression testing workflow using gdiff and by resolving the httpgd installation challenge using remotes.

- Installs gdiff and required system dependencies for graphical difference testing (#271).

- Installs httpgd from GitHub via remotes to resolve package availability issues (#227).

