### PR TITLE
feature/add build flag and setup script for positron

### DIFF
--- a/docs/tutorials/building_r.md
+++ b/docs/tutorials/building_r.md
@@ -61,7 +61,7 @@ cd $BUILDDIR
 directory.  This step takes ~1 minute on the codespace.
 
 ```bash
-$TOP_SRCDIR/configure --with-valgrind-instrumentation=1
+$TOP_SRCDIR/configure --enable-R-shlib --with-valgrind-instrumentation=1
 
 ```
 

--- a/scripts/setup_positron.sh
+++ b/scripts/setup_positron.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Setup script for Positron IDE with r-dev-env
+# Configures custom R binaries and root folders for both Gitpod and Codespaces
+
+echo "Setting up Positron IDE configuration for r-dev-env..."
+
+# Create .vscode directory if it doesn't exist
+mkdir -p .vscode
+
+# Determine the correct workspace path based on environment
+if [ -d "/workspace/r-dev-env" ]; then
+    WORKSPACE_PATH="/workspace/r-dev-env"
+    echo "Detected Gitpod environment"
+elif [ -d "/workspaces/r-dev-env" ]; then
+    WORKSPACE_PATH="/workspaces/r-dev-env"
+    echo "Detected Codespaces/DevContainer environment"
+else
+    echo "Warning: Could not detect workspace environment"
+    WORKSPACE_PATH="/workspace/r-dev-env"
+fi
+
+# Create Positron settings
+cat > .vscode/settings.json << EOF
+{
+  "positron.r.customBinaries": ["$WORKSPACE_PATH/build/r-devel/bin/R"],
+  "positron.r.customRootFolders": ["$WORKSPACE_PATH"]
+}
+EOF
+
+echo "Positron configuration created at .vscode/settings.json"
+echo "R binary path: $WORKSPACE_PATH/build/r-devel/bin/R"
+echo ""
+echo "After building R with --enable-R-shlib, use 'R: Select Interpreter' in Positron"
+echo "to select the custom R binary for proper console functionality."


### PR DESCRIPTION
This pull request addresses the issue where Positron IDE's R console exits abnormally with signal 6 (`SIGABRT`) due to the absence of the shared library `libR.so`. The underlying problem is that the standard R build does not create this shared library, which Positron's internal ark kernel requires for remote SSH sessions.

Changes include:

- Modification of the R build process to add the `--enable-R-shlib` configure flag, enabling shared library creation for `libR.so`.

-  Addition of a new setup script (`scripts/setup_positron.sh`) to automatically configure Positron IDE settings for custom R binaries and root folders in typical remote development environments such as Gitpod and Codespaces.

Solves #193 

