### PR TITLE
Update editor settings (minimap and settings for R/C code)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,22 +10,36 @@
         "vscode": {
             "settings": {
                 "git.ignoredRepositories": ["."],
-                  "files.exclude": {
-                       "**/.devcontainer": true,
-                       "**/.git": true,
-                       "**/.github": true,
-                       "**/.gitignore": true,
-                       "**/.gitpod.Dockerfile": true,
-                       "**/.gitpod.yml": true,
-                       "**/.markdownlint-cli2.yaml": true,
-                       "**/.pre-commit-config.yaml": true,
-                       "**/Dockerfile": true,
-                       "**/mkdocs.yml": true,
-                       "**/scripts": true
-  },
-                "editor.tabSize": 8,
-                "editor.indentSize": 4,
-                "editor.detectIndentation": false,
+                "files.exclude": {
+                    "**/.devcontainer": true,
+                    "**/.git": true,
+                    "**/.github": true,
+                    "**/.gitignore": true,
+                    "**/.gitpod.Dockerfile": true,
+                    "**/.gitpod.yml": true,
+                    "**/.markdownlint-cli2.yaml": true,
+                    "**/.pre-commit-config.yaml": true,
+                    "**/Dockerfile": true,
+                    "**/mkdocs.yml": true,
+                    "**/scripts": true
+                },
+                "[c]": {
+                    "editor.indentSize": 4,
+                    "editor.tabSize": 8,
+                    "editor.insertSpaces": true,
+                    "editor.detectIndentation": false
+                },
+                "[r]": {
+                    "editor.indentSize": 4,
+                    "editor.tabSize": 8,
+                    "editor.insertSpaces": true,
+                    "editor.detectIndentation": false
+                },
+                "editor.formatOnSave": false,
+                "editor.renderWhitespace": "all",
+                "editor.minimap.autohide": "mouseover",
+                "diffEditor.ignoreTrimWhitespace": false,
+                "files.trimTrailingWhitespace": true,
                 "r.lsp.diagnostics": false,
                 "r.plot.useHttpgd": true,
                 "r.rpath.linux": "/usr/bin/R",


### PR DESCRIPTION
This fixes #285 to only show the minimap on mouseover and also refines the editor settings, according to https://github.com/r-devel/r-dev-day/issues/105#issuecomment-3173086445, copied here to include the comments

```jsonc
{
  // Editor settings for C files
  // Cannot set to auto replace 8 spaces with tab (https://github.com/Microsoft/vscode/issues/ #42740, #5394)
  "[c]": {
    // An indent is 4 spaces
    "editor.indentSize": 4,
    // But display 8 spaces as a single tab
    "editor.tabSize": 8,
    // Need this to get indent size 4, else uses tabs to indent
    "editor.insertSpaces": true,
    // If set true, detects settings from the code in the file
    "editor.detectIndentation": false,
  },
  // Editor settings for R files
  "[r]": {
    "editor.indentSize": 4,
    "editor.tabSize": 8,
    "editor.insertSpaces": true,
    "editor.detectIndentation": false
  },
  // There isn't a formatter that works great with R itself
  "editor.formatOnSave": false,
  // Shows the difference between 4 spaces and 8 spaces (tab) visually
  "editor.renderWhitespace": "all",
  // Show whitespace changes in the diff editor to help us get it right
  "diffEditor.ignoreTrimWhitespace": false,
  // Trim trailing whitespace after a line, or on a blank line.
  // You may need to turn this off in some files where historically
  // trailing whitespace has not been trimmed, but otherwise it is
  // good practice to trim it.
  "files.trimTrailingWhitespace": true,
  // Turn off {languageserver} linting for R files
  "r.lsp.diagnostics": false
}
```