### PR TITLE
install unigd as required for new R versions

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -13,9 +13,6 @@
 source("~/.vscode-R/init.R")
 .First.sys()
 
-# The remotes package is installed to install httpgd from GitHub
-# The gdiff package is installed to support visual difference testing
-
 # Configure r-universe for binary package installations dynamically
 linux_binary_repo <- function(universe){
   runiverse <- sprintf('r-universe.dev/bin/linux/%s-%s/%s/',
@@ -29,6 +26,15 @@ linux_binary_repo <- function(universe){
 options(repos = c(
   cran = linux_binary_repo("cran")
 ))
+rm(linux_binary_repo)
+
+# http graphics device requires unigd to be built for current R version
+build_ver <- installed.packages()["unigd", "Built"]
+r_ver <- paste(R.version$major, substr(R.version$minor, 1, 1), sep = ".")
+if (substr(build_ver, 1, 3) != r_ver){
+    message("installing unigd package (graphics backend) for R ", r_ver)
+    suppressMessages(install.packages("unigd", quiet = TRUE))
+}
 
 # For PNG graphics uncomment following lines
 # options(vsc.use_httpgd = FALSE,

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,10 @@
 {
     "name": "R-Dev-Env",
     "image": "ghcr.io/r-devel/r-dev-env:devel",
-    "runArgs": ["--cap-add=SYS_PTRACE"],
+    "runArgs": [
+        "--cap-add=SYS_PTRACE",
+        "--dns=8.8.8.8"
+    ],
     "remoteUser": "vscode",
     "hostRequirements": {
         "cpus": 4


### PR DESCRIPTION
Currently the http graphics device doesn't work when we switch to r-devel, with the message:

```
Error in unigd_ugd_(bg, width, height, pointsize, aliases, reset_par) : 
  Graphics API version mismatch
```

This is because the unigd package needs to be built for the current version of R.

This PR updates the .Rprofile to install unigd if the version found was not built for the current major.minor version of R.

It also sets the DNS to allow installing packages in the container on a local setup (this is also required to install the CodeLLDB platform package)