### PR TITLE
Manifest

### DIFF
--- a/.github/workflows/call_jobs.yml
+++ b/.github/workflows/call_jobs.yml
@@ -3,8 +3,8 @@ name: Call reusable workflows
 on:
   push:
     branches:
-     - main
-     - devel
+      - main
+      - devel
   pull_request:
     branches:
       - main
@@ -55,3 +55,16 @@ jobs:
   #    registry: ghcr.io
   #    platform: buildx
   #  secrets: inherit
+  call-workflow-manifest:
+    needs:
+      - call-workflow-amd64
+      - call-workflow-arm64
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/reuse-build-manifest.yml
+    with:
+      image_name: ${{ github.repository }}
+      ref_name: ${{ github.ref_name }}
+      registry: ghcr.io
+    secrets: inherit

--- a/.github/workflows/call_jobs.yml
+++ b/.github/workflows/call_jobs.yml
@@ -5,17 +5,11 @@ on:
     branches:
       - main
       - devel
-  pull_request:
-    branches:
-      - main
-      - devel
-    types:
-      - closed
     paths:
       - '.github/workflows/reuse-build-and-publish-amd.yml'
-      - '.devcontainer/devcontainer.json'
+      - '.github/workflows/reuse-build-and-publish-arm.yml'
+      - '.github/workflows/reuse-build-manifest.yml'
       - 'Dockerfile'
-      - 'reinstall-cmake.sh'
       - 'VERSION'
 
 jobs:

--- a/.github/workflows/reuse-build-and-publish-arm.yml
+++ b/.github/workflows/reuse-build-and-publish-arm.yml
@@ -3,7 +3,7 @@
 # separate terms of service, privacy policy, and support
 # documentation.
 
-name: Build and publish amd 64 Docker image
+name: Build and publish arm64 Docker image
 
 on:
   workflow_call:
@@ -35,6 +35,8 @@ permissions:
 jobs:
   reuse-build-and-push:
 
+    # no "ubuntu-latest-arm" so need to specify version
+    # version here does not need to match that used in r-dev-env/Dockerfile
     runs-on: ubuntu-26.04-arm
 
     steps:

--- a/.github/workflows/reuse-build-and-publish-manifest.yml
+++ b/.github/workflows/reuse-build-and-publish-manifest.yml
@@ -1,0 +1,36 @@
+name: Create multi-arch manifest
+
+on:
+  workflow_call:
+    inputs:
+      image_name:
+        required: true
+        type: string
+      ref_name:
+        required: true
+        type: string
+      registry:
+        required: true
+        type: string
+
+jobs:
+  manifest:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Login to registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ inputs.registry }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create multi-arch manifest
+        run: |
+          docker buildx imagetools create \
+            -t ${{ inputs.registry }}/${{ inputs.image_name }}:${{ inputs.ref_name }} \
+            ${{ inputs.registry }}/${{ inputs.image_name }}:${{ inputs.ref_name }}-amd \
+            ${{ inputs.registry }}/${{ inputs.image_name }}:${{ inputs.ref_name }}-arm

--- a/.github/workflows/reuse-build-and-publish.yml
+++ b/.github/workflows/reuse-build-and-publish.yml
@@ -3,7 +3,7 @@
 # separate terms of service, privacy policy, and support
 # documentation.
 
-name: Build and publish amd 64 Docker image
+name: Build and publish amd64 Docker image
 
 on:
   workflow_call:
@@ -35,7 +35,7 @@ permissions:
 jobs:
   reuse-build-and-push:
 
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# Uses latest ubuntu on https://mcr.microsoft.com/en-us/artifact/mar/devcontainers/cpp/tags
 FROM mcr.microsoft.com/devcontainers/cpp:dev-ubuntu
 
 # Update and install necessary dependencies


### PR DESCRIPTION
* Add job to create manifest so that Docker will pull the `-arm` or `-amd` image as appropriate (e.g. if `.devcontainer/devcontainer.json` has `"image": "ghcr.io/r-devel/r-dev-env:devel"`,  `devel-amd` should be pulled on a Intel/AMD machine and `devel-arm` on an Apple Silicon / ARM machine)
* Updated the `call_jobs.yml` workflow to 
    * create the manifest after building the arm64 and amd64 images
    * only build and publish the images and manifest when pushing a commit that changes relevant files
    
Also checked that mcr.microsoft.com/devcontainers/cpp:dev-ubuntu is using Ubuntu 26.04, so if rebuild successful we should have the Ubuntu version on which R universe Linux binaries are currently built.