### PR TITLE
Add sshd feature to the devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,9 @@
 {
     "name": "R-Dev-Env",
     "image": "ghcr.io/r-devel/r-dev-env:main",
+    "features": {
+        "ghcr.io/devcontainers/features/sshd:1": {}
+    },
     "hostRequirements": {
         "cpus": 4
     },

--- a/.github/workflows/build-mkdocs-website.yml
+++ b/.github/workflows/build-mkdocs-website.yml
@@ -65,5 +65,7 @@ jobs:
         run: |
            echo "Deploying from branch: ${{ github.ref_name }}"
            echo "Commit: ${{ github.sha }}"
-           git remote set-url origin https://x-access-token:${GH_PAT}@github.com/${{ steps.config.outputs.target_repo }}
+           git config --global credential.helper store
+           echo "https://x-access-token:${GH_PAT}@github.com" > ~/.git-credentials
+           git remote set-url origin https://github.com/${{ steps.config.outputs.target_repo }}
            mkdocs gh-deploy --config-file mkdocs.yml --remote-branch gh-pages --force

--- a/.github/workflows/build-mkdocs-website.yml
+++ b/.github/workflows/build-mkdocs-website.yml
@@ -6,7 +6,7 @@ on:
     branches: ["main","devel"]
     types: [closed]
     paths:
-      - 'build-mkdocs-website.yml'
+      - '.github/workflows/build-mkdocs-website.yml'
       - 'docs/**/**'
       - 'mkdocs.yml'
 

--- a/.github/workflows/build-mkdocs-website.yml
+++ b/.github/workflows/build-mkdocs-website.yml
@@ -12,7 +12,7 @@ on:
 
 permissions:
   contents: write
-  
+
 jobs:
   build-and-deploy:
     if: |

--- a/.github/workflows/build-mkdocs-website.yml
+++ b/.github/workflows/build-mkdocs-website.yml
@@ -10,34 +10,60 @@ on:
       - 'docs/**/**'
       - 'mkdocs.yml'
 
-permissions:
-  contents: write
-
 jobs:
   build-and-deploy:
     if: |
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.x
 
       - name: Install dependencies
         run: pip install mkdocs mkdocs-material[imaging]
 
+      - name: Determine deployment settings
+        id: config
+        run: |
+          if [[ "${{ github.ref_name }}" == "main" ]]; then
+            echo "target_repo=${{ github.repository }}" >> "$GITHUB_OUTPUT"
+            echo "url=https://contributor.r-project.org/r-dev-env" >> "$GITHUB_OUTPUT"
+          else
+            echo "target_repo=r-devel/r-dev-env-devel" >> "$GITHUB_OUTPUT"
+            echo "url=https://contributor.r-project.org/r-dev-env-devel" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Modify site_url in mkdocs.yml
+        run: |
+          echo "Setting site_url to ${{ steps.config.outputs.url }}"
+          sed -i "s|^site_url:.*|site_url: '${{ steps.config.outputs.url }}'|" mkdocs.yml
+
       - name: Build MkDocs
         run: mkdocs build
 
-      - name: Deploy to GitHub Pages
-        run: |
-           mkdocs gh-deploy --force
-           git push origin gh-pages
+      - name: Validate PAT
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_PAT: ${{ secrets.R_DEV_ENV_DOCS }}
+        run: |
+          curl -H "Authorization: token $GH_PAT" https://api.github.com/user || {
+            echo "PAT is invalid or expired" >&2
+            exit 1
+          }
+
+      - name: Deploy to GitHub Pages
+        env:
+          GH_PAT: ${{ secrets.R_DEV_ENV_DOCS }}
+        run: |
+           echo "Deploying from branch: ${{ github.ref_name }}"
+           echo "Commit: ${{ github.sha }}"
+           git remote set-url origin https://x-access-token:${GH_PAT}@github.com/${{ steps.config.outputs.target_repo }}
+           mkdocs gh-deploy --config-file mkdocs.yml --remote-branch gh-pages --force

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v5.0.0
+  rev: v6.0.0
   hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
@@ -10,7 +10,7 @@ repos:
     -   id: check-added-large-files
 
 - repo: https://github.com/DavidAnson/markdownlint-cli2
-  rev: v0.18.1
+  rev: v0.20.0
   hooks:
     - id: markdownlint-cli2
       args: []

--- a/INIT
+++ b/INIT
@@ -1,3 +1,0 @@
-This file is used as a marker to indicate when a codespace is first opened.
-
-See `scripts/welcome_message.sh` for use.

--- a/docs/tutorials/patch_update.md
+++ b/docs/tutorials/patch_update.md
@@ -14,14 +14,24 @@ this first.
 
 Go to the source directory and use `svn diff` to create a patch.
 
+**Use a descriptive patch name with the bug number and a short description,
+rather than a generic name like `patch.diff`.**
+
 ```bash
 cd $TOP_SRCDIR
-svn diff > $PATCHDIR/patch.diff
+svn diff > $PATCHDIR/16629-infinite-recursion.diff
 ```
+
+> e.g. `16629-infinite-recursion.diff` - This name follows the convention:
+bug number (16629), short description (infinite-recursion), and .diff extension,
+ making patches easy to identify and review.
 
 The patch file will be saved in the directory specified by the PATCHDIR
 environment variable that is defined when the codespace starts
 
 ```bash
-echo $PATCHDIR/patch.diff
+ls $PATCHDIR
 ```
+
+lists all patch files in your patch directory, allowing you to easily
+see and verify the patch files you have created.

--- a/docs/tutorials/patch_update.md
+++ b/docs/tutorials/patch_update.md
@@ -22,12 +22,12 @@ cd $TOP_SRCDIR
 svn diff > $PATCHDIR/16629-infinite-recursion.diff
 ```
 
-> e.g. `16629-infinite-recursion.diff` - This name follows the convention:
-bug number (16629), short description (infinite-recursion), and .diff extension,
- making patches easy to identify and review.
+The example above uses `16629-infinite-recursion.diff` - this name follows the
+convention: bug number (16629), short description (infinite-recursion), and
+`.diff` extension, making patches easy to identify and review.
 
 The patch file will be saved in the directory specified by the PATCHDIR
-environment variable that is defined when the codespace starts
+environment variable that is defined when the codespace starts.
 
 ```bash
 ls $PATCHDIR


### PR DESCRIPTION
I just found myself unable to connect to the GitHub Codespace via SSH. If using a custom image, then this feature is required for the SSH to work. Per the `gh` CLI' message:
```
error getting ssh server details: failed to start SSH server:
Please check if an SSH server is installed in the container.
If the docker image being used for the codespace does not have an SSH server,
install it in your Dockerfile or, for codespaces that use Debian-based images,
you can add the following to your devcontainer.json:

"features": {
    "ghcr.io/devcontainers/features/sshd:1": {
        "version": "latest"
    }
}
```
